### PR TITLE
Implement basic ReAct agent loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,4 @@ AI-powered Jira + Confluence automation platform.
 See [Project Charter](PROJECT_CHARTER.md) for objectives, use cases, and success metrics.
 
 For a high-level architectural overview, see [Architecture Blueprint](docs/ARCHITECTURE_BLUEPRINT.md).
+See [Core Agent Loop](docs/CORE_AGENT_LOOP.md) for implementation details of the ReAct loop.

--- a/docs/CORE_AGENT_LOOP.md
+++ b/docs/CORE_AGENT_LOOP.md
@@ -1,0 +1,9 @@
+# Core Agent Loop
+
+The agent follows a simple ReAct loop implemented with LangGraph:
+
+1. **Thought** – the LLM reasons about the current state and decides on an action.
+2. **Action** – the chosen tool is invoked with parsed arguments.
+3. **Observation** – the tool output is recorded and fed back into the next prompt.
+
+The `CoreAgent` class in `src/ticketsmith/core_agent.py` runs one iteration of this loop and maintains a history of steps.

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ atlassian-python-api
 
 black
 flake8
+langgraph==0.0.10

--- a/src/ticketsmith/cli.py
+++ b/src/ticketsmith/cli.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import click
+
+from .core_agent import CoreAgent
+
+
+def echo_tool(message: str) -> str:
+    """Return the given message."""
+    return message
+
+
+def dummy_llm(prompt: str) -> str:
+    """Simple LLM stub that always returns a predefined action."""
+    return "Thought: echoing message\nAction: echo_tool(message='Hello')"
+
+
+@click.command()
+@click.argument("text")
+def main(text: str) -> None:
+    """Run the core agent once with the provided text."""
+    agent = CoreAgent(dummy_llm, {"echo_tool": echo_tool})
+    result = agent.run(text)
+    click.echo(result)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/ticketsmith/core_agent.py
+++ b/src/ticketsmith/core_agent.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import re
+from typing import Any, Callable, Dict
+
+from langgraph import graph
+
+
+class CoreAgent:
+    """Simple ReAct agent using a LangGraph state machine."""
+
+    def __init__(
+        self, llm: Callable[[str], str], tools: Dict[str, Callable[..., Any]]
+    ) -> None:
+        """Create a CoreAgent.
+
+        Args:
+            llm: Function that generates a thought and action text from a
+                prompt.
+            tools: Mapping of tool names to callables.
+        """
+        self.llm = llm
+        self.tools = tools
+        self._graph = self._build_graph()
+
+    @staticmethod
+    def _build_graph() -> graph.Pregel:
+        """Construct the underlying LangGraph state machine."""
+        g = graph.Graph()
+        g.add_node("thought", CoreAgent._thought_step)
+        g.add_node("act", CoreAgent._action_step)
+        g.add_node("observe", CoreAgent._observe_step)
+        g.add_edge("thought", "act")
+        g.add_edge("act", "observe")
+        g.set_entry_point("thought")
+        g.set_finish_point("observe")
+        return g.compile()
+
+    @staticmethod
+    def _thought_step(state: Dict[str, Any]) -> Dict[str, Any]:
+        """Generate the next thought using the LLM."""
+        prompt = CoreAgent._build_prompt(state)
+        llm = state["llm"]
+        state["llm_output"] = llm(prompt)
+        return state
+
+    @staticmethod
+    def _action_step(state: Dict[str, Any]) -> Dict[str, Any]:
+        """Parse the action and execute the corresponding tool."""
+        tool_name, kwargs = CoreAgent.parse_action(state["llm_output"])
+        tool = state["tools"].get(tool_name)
+        if tool is None:
+            raise ValueError(f"Unknown tool: {tool_name}")
+        state["action"] = {"tool": tool_name, "args": kwargs}
+        state["observation"] = tool(**kwargs)
+        return state
+
+    @staticmethod
+    def _observe_step(state: Dict[str, Any]) -> Dict[str, Any]:
+        """Record the observation in history."""
+        history = state.setdefault("history", [])
+        history.append(
+            {
+                "thought": state.get("llm_output"),
+                "action": state.get("action"),
+                "observation": state.get("observation"),
+            }
+        )
+        return state
+
+    @staticmethod
+    def _build_prompt(state: Dict[str, Any]) -> str:
+        """Build the prompt for the LLM."""
+        prompt = ""
+        for step in state.get("history", []):
+            prompt += f"Thought: {step['thought']}\n"
+            prompt += f"Action: {step['action']}\n"
+            prompt += f"Observation: {step['observation']}\n"
+        if "input" in state:
+            prompt += f"Input: {state['input']}\n"
+        prompt += "Respond with 'Thought: <reasoning>\nAction: <tool>(<args>)'"
+        return prompt
+
+    def run(self, text: str) -> Dict[str, Any]:
+        """Execute one Thought-Action-Observation loop."""
+        state: Dict[str, Any] = {
+            "input": text,
+            "tools": self.tools,
+            "llm": self.llm,
+        }
+        return self._graph.invoke(state)
+
+    @staticmethod
+    def parse_action(response: str) -> tuple[str, Dict[str, Any]]:
+        """Extract tool name and arguments from LLM output."""
+        match = re.search(r"Action:\s*(\w+)\((.*)\)", response)
+        if not match:
+            raise ValueError("Could not parse action")
+        name = match.group(1)
+        args_str = match.group(2).strip()
+        args = {}
+        if args_str:
+            args = eval(f"dict({args_str})", {"__builtins__": {"dict": dict}})
+        return name, args

--- a/tests/test_core_agent.py
+++ b/tests/test_core_agent.py
@@ -1,0 +1,17 @@
+from ticketsmith.core_agent import CoreAgent
+
+
+def test_single_loop():
+    def llm(_prompt: str) -> str:
+        return "Thought: say hello\nAction: echo_tool(message='hi')"
+
+    def echo_tool(message: str) -> str:
+        return message
+
+    agent = CoreAgent(llm, {"echo_tool": echo_tool})
+    result = agent.run("test")
+    history = result.get("history")
+    assert history is not None
+    assert history[0]["observation"] == "hi"
+    assert history[0]["action"]["tool"] == "echo_tool"
+    assert history[0]["action"]["args"] == {"message": "hi"}


### PR DESCRIPTION
## Summary
- add `CoreAgent` implementing a ReAct loop with LangGraph
- provide CLI and unit test
- document the new core agent loop and reference it from README
- update requirements for langgraph

## Testing
- `flake8 src tests`
- `black src tests`
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fb22d3084832a9a61abdbc9bb5344