### PR TITLE
Add step planning module with tests

### DIFF
--- a/src/ticketsmith/__init__.py
+++ b/src/ticketsmith/__init__.py
@@ -1,0 +1,4 @@
+from .core_agent import CoreAgent
+from .planning import StepPlanner, PlanResult
+
+__all__ = ["CoreAgent", "StepPlanner", "PlanResult"]

--- a/src/ticketsmith/planning.py
+++ b/src/ticketsmith/planning.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Callable, List
+
+
+@dataclass
+class PlanResult:
+    """Result of executing a plan step."""
+
+    step: str
+    result: str
+
+
+class StepPlanner:
+    """Simple planner that decomposes tasks into steps and executes them."""
+
+    def __init__(self, llm: Callable[[str], str]) -> None:
+        """Create planner with the provided LLM callable."""
+        self.llm = llm
+
+    def plan(self, task: str) -> List[str]:
+        """Generate a plan for a complex task.
+
+        Args:
+            task: High level user request.
+
+        Returns:
+            A list of step descriptions.
+        """
+        prompt = (
+            "Break down the following task into a numbered list of steps.\n"
+            f"Task: {task}\nSteps:"
+        )
+        response = self.llm(prompt)
+        return self._parse_steps(response)
+
+    def execute(
+        self, steps: List[str], executor: Callable[[str], str]
+    ) -> List[PlanResult]:
+        """Execute each step with the provided executor function."""
+        results: List[PlanResult] = []
+        for step in steps:
+            result = executor(step)
+            results.append(PlanResult(step=step, result=result))
+        return results
+
+    def reflect(self, task: str, results: List[PlanResult]) -> List[str]:
+        """Ask the LLM for a revised plan based on execution results."""
+        prompt = f"Task: {task}\n"
+        for r in results:
+            prompt += f"Step: {r.step}\nResult: {r.result}\n"
+        prompt += (
+            "The task is not fully solved. "
+            "Provide a new plan as a numbered list of steps."
+        )
+        response = self.llm(prompt)
+        return self._parse_steps(response)
+
+    @staticmethod
+    def _parse_steps(text: str) -> List[str]:
+        """Extract numbered steps from LLM output."""
+        steps: List[str] = []
+        for line in text.splitlines():
+            match = re.match(r"\s*\d+\.\s*(.+)", line)
+            if match:
+                steps.append(match.group(1).strip())
+        if not steps and text.strip():
+            steps.append(text.strip())
+        return steps

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import os
+import sys
+
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src"))
+)

--- a/tests/test_planning.py
+++ b/tests/test_planning.py
@@ -1,0 +1,35 @@
+from ticketsmith.planning import StepPlanner, PlanResult
+
+
+def test_plan_and_execute():
+    def llm(prompt: str) -> str:
+        return "1. first\n2. second"
+
+    planner = StepPlanner(llm)
+    steps = planner.plan("do stuff")
+    assert steps == ["first", "second"]
+
+    def executor(step: str) -> str:
+        return f"{step} done"
+
+    results = planner.execute(steps, executor)
+    assert results[0].result == "first done"
+    assert results[1].result == "second done"
+
+
+def test_reflect():
+    responses = {
+        "plan": "1. step",
+        "reflect": "1. new step",
+    }
+
+    def llm(prompt: str) -> str:
+        if "The task is not fully solved" in prompt:
+            return responses["reflect"]
+        return responses["plan"]
+
+    planner = StepPlanner(llm)
+    steps = planner.plan("task")
+    results = [PlanResult(step=steps[0], result="failure")]
+    new_steps = planner.reflect("task", results)
+    assert new_steps == ["new step"]


### PR DESCRIPTION
## Summary
- implement `StepPlanner` for decomposing tasks into steps
- expose planner in package `__all__`
- add tests covering planning functionality
- provide pytest configuration to load `src`

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fb744b614832a9b80c5cef48b8f18