### PR TITLE
Add tool dispatcher and structured tools

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ atlassian-python-api
 black
 flake8
 langgraph==0.0.10
+pydantic

--- a/src/ticketsmith/__init__.py
+++ b/src/ticketsmith/__init__.py
@@ -1,6 +1,7 @@
 from .core_agent import CoreAgent
 from .memory import ConversationBuffer, SimpleVectorStore
 from .planning import StepPlanner, PlanResult
+from .tools import Tool, ToolDispatcher, tool
 
 __all__ = [
     "CoreAgent",
@@ -8,4 +9,7 @@ __all__ = [
     "SimpleVectorStore",
     "StepPlanner",
     "PlanResult",
+    "Tool",
+    "ToolDispatcher",
+    "tool",
 ]

--- a/src/ticketsmith/cli.py
+++ b/src/ticketsmith/cli.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 import click
 
 from .core_agent import CoreAgent
+from .tools import ToolDispatcher, tool
 
 
+@tool(name="echo_tool", description="Return the given message.")
 def echo_tool(message: str) -> str:
     """Return the given message."""
     return message
@@ -19,7 +21,8 @@ def dummy_llm(prompt: str) -> str:
 @click.argument("text")
 def main(text: str) -> None:
     """Run the core agent once with the provided text."""
-    agent = CoreAgent(dummy_llm, {"echo_tool": echo_tool})
+    dispatcher = ToolDispatcher([echo_tool])
+    agent = CoreAgent(dummy_llm, dispatcher)
     result = agent.run(text)
     click.echo(result)
 

--- a/src/ticketsmith/tools.py
+++ b/src/ticketsmith/tools.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Iterable
+import inspect
+
+from pydantic import BaseModel, ValidationError, create_model
+
+
+@dataclass
+class Tool:
+    """Encapsulate a callable with a Pydantic argument schema."""
+
+    name: str
+    description: str
+    schema: type[BaseModel]
+    func: Callable[..., Any]
+
+    def __call__(self, **kwargs: Any) -> Any:
+        """Validate arguments and execute the underlying function."""
+        try:
+            data = self.schema(**kwargs)
+        except ValidationError as exc:
+            raise ValueError(
+                f"Invalid arguments for tool '{self.name}': {exc}"
+            ) from exc
+        return self.func(**data.model_dump())
+
+
+def tool(name: str, description: str) -> Callable[[Callable[..., Any]], Tool]:
+    """Decorator to convert a function into a :class:`Tool`."""
+
+    def decorator(fn: Callable[..., Any]) -> Tool:
+        parameters: Dict[str, tuple[Any, Any]] = {}
+        # fmt: off
+        for param in inspect.signature(fn).parameters.values():
+            annotation = (
+                param.annotation
+                if param.annotation is not inspect._empty
+                else Any
+            )
+            default = (
+                param.default
+                if param.default is not inspect._empty
+                else ...
+            )
+            parameters[param.name] = (annotation, default)
+        # fmt: on
+        schema = create_model(f"{fn.__name__.title()}Args", **parameters)
+        return Tool(name=name, description=description, schema=schema, func=fn)
+
+    return decorator
+
+
+class ToolDispatcher:
+    """Execute tools by name with argument validation."""
+
+    def __init__(self, tools: Iterable[Tool]) -> None:
+        self._tools: Dict[str, Tool] = {t.name: t for t in tools}
+
+    def dispatch(self, name: str, **kwargs: Any) -> Any:
+        if name not in self._tools:
+            raise ValueError(f"Unknown tool: {name}")
+        return self._tools[name](**kwargs)
+
+    def get(self, name: str) -> Tool | None:
+        return self._tools.get(name)
+
+    def list(self) -> Dict[str, Tool]:
+        return dict(self._tools)

--- a/tests/test_core_agent.py
+++ b/tests/test_core_agent.py
@@ -1,14 +1,17 @@
 from ticketsmith.core_agent import CoreAgent
+from ticketsmith.tools import ToolDispatcher, tool
 
 
 def test_single_loop():
     def llm(_prompt: str) -> str:
         return "Thought: say hello\nAction: echo_tool(message='hi')"
 
+    @tool(name="echo_tool", description="Return the given message.")
     def echo_tool(message: str) -> str:
         return message
 
-    agent = CoreAgent(llm, {"echo_tool": echo_tool})
+    dispatcher = ToolDispatcher([echo_tool])
+    agent = CoreAgent(llm, dispatcher)
     result = agent.run("test")
     history = result.get("history")
     assert history is not None

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,5 +1,6 @@
 from ticketsmith.core_agent import CoreAgent
 from ticketsmith.memory import ConversationBuffer, SimpleVectorStore
+from ticketsmith.tools import ToolDispatcher, tool
 
 
 def test_conversation_buffer_window():
@@ -8,11 +9,12 @@ def test_conversation_buffer_window():
     def llm(_prompt: str) -> str:
         return "Thought: hi\nAction: echo_tool(message='x')"
 
+    @tool(name="echo_tool", description="Return the message.")
     def echo_tool(message: str) -> str:
         return message
 
-    tools = {"echo_tool": echo_tool}
-    agent = CoreAgent(llm, tools, conversation_buffer=buffer)
+    dispatcher = ToolDispatcher([echo_tool])
+    agent = CoreAgent(llm, dispatcher, conversation_buffer=buffer)
     agent.run("one")
     assert len(buffer.get_history()) == 1
     agent.run("two")

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,0 +1,18 @@
+from ticketsmith.tools import ToolDispatcher, tool
+import pytest
+
+
+@tool(name="add", description="Add two integers together.")
+def add(a: int, b: int) -> int:
+    return a + b
+
+
+def test_dispatcher_executes_tool():
+    dispatcher = ToolDispatcher([add])
+    assert dispatcher.dispatch("add", a=2, b=3) == 5
+
+
+def test_dispatcher_validates_arguments():
+    dispatcher = ToolDispatcher([add])
+    with pytest.raises(ValueError):
+        dispatcher.dispatch("add", a="x", b=1)


### PR DESCRIPTION
## Summary
- create `Tool`, `tool` decorator, and `ToolDispatcher`
- integrate dispatcher in `CoreAgent`
- update CLI and tests to use structured tools
- add unit tests for dispatcher
- add pydantic requirement

## Testing
- `black -q .`
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686fc0ae42f4832a9cf81d335b9d9891