### PR TITLE
Add local inference guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,9 @@ docker compose up inference
 
 Requests must include `Authorization: Bearer <API key>` to access the
 `/v1/chat/completions` endpoint.
+
+### Local `llama-cpp-python` Inference
+
+Developers can run quantized models directly on their machines for quick
+experimentation. See [Local Inference with llama-cpp-python](docs/LOCAL_INFERENCE.md)
+for installation instructions and a sample script.

--- a/docs/LOCAL_INFERENCE.md
+++ b/docs/LOCAL_INFERENCE.md
@@ -1,0 +1,60 @@
+# Local Inference with llama-cpp-python
+
+This guide shows how to run quantized GGUF models on your own machine using `llama-cpp-python`.
+
+## Installation
+
+### macOS (Apple Silicon)
+
+Install the library with Metal acceleration:
+
+```bash
+CMAKE_ARGS="-DLLAMA_METAL=on" FORCE_CMAKE=1 pip install --no-binary :all: llama-cpp-python
+```
+
+### Linux (CUDA)
+
+Install with CUDA support by setting the appropriate CMake flags:
+
+```bash
+CMAKE_ARGS="-DLLAMA_CUDA=on" FORCE_CMAKE=1 pip install --no-binary :all: llama-cpp-python
+```
+
+A CPU-only build can be installed with:
+
+```bash
+pip install llama-cpp-python
+```
+
+## Download Quantized GGUF Models
+
+Quantized models are available on Hugging Face:
+
+- [TheBloke/Llama-3-8B-Instruct-GGUF](https://huggingface.co/TheBloke/Llama-3-8B-Instruct-GGUF)
+- [TheBloke/Mistral-7B-Instruct-v0.2-GGUF](https://huggingface.co/TheBloke/Mistral-7B-Instruct-v0.2-GGUF)
+
+Download a `q4_0` or `q4_K_M` file and note its path.
+
+## Example Script
+
+```python
+from llama_cpp import Llama
+
+# Path to your downloaded GGUF model
+MODEL_PATH = "./models/llama-3-8b-instruct.Q4_K_M.gguf"
+
+def main() -> None:
+    """Run a simple prompt against the local model."""
+    llm = Llama(model_path=MODEL_PATH)
+    response = llm("Hello, world!", max_tokens=32)
+    print(response["choices"][0]["text"].strip())
+
+if __name__ == "__main__":
+    main()
+```
+
+Run the script with Python 3.11:
+
+```bash
+python3.11 scripts/local_inference.py
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ black
 flake8
 langgraph==0.0.10
 pydantic
+llama-cpp-python

--- a/scripts/local_inference.py
+++ b/scripts/local_inference.py
@@ -1,0 +1,18 @@
+"""Example script for running a GGUF model locally with llama-cpp-python."""
+
+from __future__ import annotations
+
+from llama_cpp import Llama
+
+MODEL_PATH = "./models/llama-3-8b-instruct.Q4_K_M.gguf"
+
+
+def main() -> None:
+    """Load the model and generate a short completion."""
+    llm = Llama(model_path=MODEL_PATH)
+    response = llm("Hello, world!", max_tokens=32)
+    print(response["choices"][0]["text"].strip())
+
+
+if __name__ == "__main__":
+    main()

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -229,7 +229,7 @@
   dependencies:
     - 301
   priority: 3
-  status: "pending"
+  status: "done"
   command: "pip install llama-cpp-python"
   task_id: "LLM-DEV-001"
   area: "Development"


### PR DESCRIPTION
## Summary
- document installation of `llama-cpp-python` with Metal or CUDA
- link to quantized GGUF models and show an example script
- expose the guide in `README`
- add `llama-cpp-python` dependency
- mark task 303 as done

## Testing
- `black . --exclude venv`
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686fcc463388832a841d3850a34da167