### PR TITLE
Add Atlassian auth helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ See [Project Charter](PROJECT_CHARTER.md) for objectives, use cases, and success
 For a high-level architectural overview, see [Architecture Blueprint](docs/ARCHITECTURE_BLUEPRINT.md).
 See [Core Agent Loop](docs/CORE_AGENT_LOOP.md) for implementation details of the ReAct loop.
 See [LLM Model Selection](docs/LLM_MODEL_SELECTION.md) for the selected models and Confluence matrix.
+For details on Atlassian API usage and authentication, see [Atlassian Integration](docs/ATLASSIAN_INTEGRATION.md).
 
 ## Self-Hosted Inference Server
 

--- a/docs/ATLASSIAN_INTEGRATION.md
+++ b/docs/ATLASSIAN_INTEGRATION.md
@@ -1,0 +1,22 @@
+# Atlassian Integration
+
+The project uses the [`atlassian-python-api`](https://pypi.org/project/atlassian-python-api/) library for all Jira and Confluence interactions. A shared module, `ticketsmith.atlassian_auth`, provides helper functions to create authenticated clients.
+
+## Authentication
+
+`atlassian-python-api` relies on basic authentication with an API token. The module reads the following environment variables:
+
+- `ATLASSIAN_BASE_URL` – base URL of your Atlassian cloud instance
+- `ATLASSIAN_USERNAME` – email address associated with the API token
+- `ATLASSIAN_API_TOKEN` – API token generated in your Atlassian account
+
+Example usage:
+
+```python
+from ticketsmith.atlassian_auth import get_jira_client, get_confluence_client
+
+jira = get_jira_client()
+confluence = get_confluence_client()
+```
+
+Ensure these values are stored securely, for example in a secrets manager when running in production.

--- a/src/ticketsmith/__init__.py
+++ b/src/ticketsmith/__init__.py
@@ -2,6 +2,12 @@ from .core_agent import CoreAgent
 from .memory import ConversationBuffer, SimpleVectorStore
 from .planning import StepPlanner, PlanResult
 from .tools import Tool, ToolDispatcher, tool
+from .atlassian_auth import (
+    AtlassianAuthError,
+    get_confluence_client,
+    get_jira_client,
+    get_clients,
+)
 
 __all__ = [
     "CoreAgent",
@@ -12,4 +18,8 @@ __all__ = [
     "Tool",
     "ToolDispatcher",
     "tool",
+    "AtlassianAuthError",
+    "get_jira_client",
+    "get_confluence_client",
+    "get_clients",
 ]

--- a/src/ticketsmith/atlassian_auth.py
+++ b/src/ticketsmith/atlassian_auth.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import os
+
+from atlassian import Confluence, Jira
+
+
+class AtlassianAuthError(RuntimeError):
+    """Raised when required authentication variables are missing."""
+
+
+def _get_env(name: str) -> str:
+    try:
+        return os.environ[name]
+    except KeyError as exc:
+        msg = f"Environment variable '{name}' is required"
+        raise AtlassianAuthError(msg) from exc
+
+
+def get_jira_client() -> Jira:
+    """Return an authenticated Jira client using environment variables."""
+    base_url = _get_env("ATLASSIAN_BASE_URL")
+    username = _get_env("ATLASSIAN_USERNAME")
+    token = _get_env("ATLASSIAN_API_TOKEN")
+    return Jira(url=base_url, username=username, password=token)
+
+
+def get_confluence_client() -> Confluence:
+    """Return an authenticated Confluence client using env vars."""
+    base_url = _get_env("ATLASSIAN_BASE_URL")
+    username = _get_env("ATLASSIAN_USERNAME")
+    token = _get_env("ATLASSIAN_API_TOKEN")
+    return Confluence(url=base_url, username=username, password=token)
+
+
+def get_clients() -> tuple[Jira, Confluence]:
+    """Return both Jira and Confluence clients."""
+    return get_jira_client(), get_confluence_client()

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -272,7 +272,7 @@
   dependencies:
     - 102
   priority: 1
-  status: "pending"
+  status: "done"
   command: "pip install atlassian-python-api"
   task_id: "TOOL-ATLASSIAN-001"
   area: "Development"

--- a/tests/test_atlassian_auth.py
+++ b/tests/test_atlassian_auth.py
@@ -1,0 +1,40 @@
+import os
+
+import pytest
+
+from ticketsmith import atlassian_auth
+
+
+class Dummy:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+
+def test_get_jira_client(monkeypatch):
+    monkeypatch.setitem(
+        os.environ, "ATLASSIAN_BASE_URL", "https://example.atlassian.net"
+    )
+    monkeypatch.setitem(os.environ, "ATLASSIAN_USERNAME", "user")
+    monkeypatch.setitem(os.environ, "ATLASSIAN_API_TOKEN", "token")
+
+    called = {}
+
+    def fake_jira(url, username, password):
+        called.update(url=url, username=username, password=password)
+        return Dummy(url=url, username=username, password=password)
+
+    monkeypatch.setattr(atlassian_auth, "Jira", fake_jira)
+
+    client = atlassian_auth.get_jira_client()
+    assert isinstance(client, Dummy)
+    assert called == {
+        "url": "https://example.atlassian.net",
+        "username": "user",
+        "password": "token",
+    }
+
+
+def test_missing_env(monkeypatch):
+    monkeypatch.delenv("ATLASSIAN_BASE_URL", raising=False)
+    with pytest.raises(atlassian_auth.AtlassianAuthError):
+        atlassian_auth.get_jira_client()


### PR DESCRIPTION
## Summary
- add `atlassian_auth` module with shared client creation helpers
- document Atlassian library selection and auth environment variables
- expose auth helpers in package init and update README
- mark Atlassian library task as done
- add unit tests

## Testing
- `black src tests`
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6870471cb80c832a97251bcc781f25c4