### PR TITLE
Implement Confluence tools

### DIFF
--- a/docs/ATLASSIAN_INTEGRATION.md
+++ b/docs/ATLASSIAN_INTEGRATION.md
@@ -46,3 +46,21 @@ add_jira_comment(key, "Created via tool")
 assign_jira_user(key, account_id="12345")
 transition_jira_issue(key, "Done")
 ```
+
+## Confluence Tools
+
+The project also includes helper tools for Confluence. The search tool uses
+the `siteSearch` field to mimic the Confluence UI search.
+
+```python
+from ticketsmith.confluence_tools import (
+    create_confluence_page,
+    search_confluence,
+    append_to_confluence_page,
+)
+
+# create a page then search and append content
+page_id = create_confluence_page("DOC", "Example Page", "<p>Hello</p>")
+search_results = search_confluence("Example")
+append_to_confluence_page(page_id, "<p>More text</p>")
+```

--- a/src/ticketsmith/__init__.py
+++ b/src/ticketsmith/__init__.py
@@ -8,6 +8,11 @@ from .jira_tools import (
     assign_jira_user,
     transition_jira_issue,
 )
+from .confluence_tools import (
+    create_confluence_page,
+    search_confluence,
+    append_to_confluence_page,
+)
 from .atlassian_auth import (
     AtlassianAuthError,
     get_confluence_client,
@@ -32,4 +37,7 @@ __all__ = [
     "add_jira_comment",
     "assign_jira_user",
     "transition_jira_issue",
+    "create_confluence_page",
+    "search_confluence",
+    "append_to_confluence_page",
 ]

--- a/src/ticketsmith/confluence_tools.py
+++ b/src/ticketsmith/confluence_tools.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from requests import RequestException
+
+from .tools import tool
+from .atlassian_auth import get_confluence_client
+
+CREATE_DESC = (
+    "Create a Confluence page in the given space with the provided title and body."
+)
+
+SEARCH_DESC = "Search Confluence using the siteSearch field to find relevant pages."
+
+APPEND_DESC = "Append content to an existing Confluence page by ID."
+
+
+@tool(name="create_confluence_page", description=CREATE_DESC)
+def create_confluence_page(space: str, title: str, body: str) -> str:
+    """Create a Confluence page.
+
+    Args:
+        space: Confluence space key.
+        title: Title of the new page.
+        body: Page body content in storage format.
+
+    Returns:
+        The ID of the created page.
+    """
+
+    confluence = get_confluence_client()
+    try:
+        page = confluence.create_page(space, title, body)
+        return str(page.get("id", ""))
+    except RequestException as exc:
+        raise RuntimeError(f"Failed to create page: {exc}") from exc
+
+
+@tool(name="search_confluence", description=SEARCH_DESC)
+def search_confluence(query: str) -> dict:
+    """Search Confluence pages.
+
+    Args:
+        query: Query string to search for.
+
+    Returns:
+        Raw search results from the Confluence API.
+    """
+
+    confluence = get_confluence_client()
+    cql_query = f"siteSearch ~ '{query}'"
+    try:
+        return confluence.cql(cql_query)
+    except RequestException as exc:
+        raise RuntimeError(f"Failed to search Confluence: {exc}") from exc
+
+
+@tool(name="append_to_confluence_page", description=APPEND_DESC)
+def append_to_confluence_page(page_id: str, content: str) -> str:
+    """Append content to a Confluence page.
+
+    Args:
+        page_id: Identifier of the page to update.
+        content: Content to append in storage format.
+
+    Returns:
+        Confirmation message when complete.
+    """
+
+    confluence = get_confluence_client()
+    try:
+        confluence.append_page(page_id, content)
+        return "content appended"
+    except RequestException as exc:
+        raise RuntimeError(f"Failed to append content: {exc}") from exc

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -320,7 +320,7 @@
     - 204
     - 401
   priority: 2
-  status: "pending"
+  status: "done"
   command: null
   task_id: "TOOL-CONFLUENCE-001"
   area: "Development"

--- a/tests/test_confluence_tools.py
+++ b/tests/test_confluence_tools.py
@@ -1,0 +1,43 @@
+from ticketsmith import confluence_tools
+
+
+class DummyConfluence:
+    def __init__(self):
+        self.calls = []
+
+    def create_page(self, space, title, body):
+        self.calls.append(("create", space, title, body))
+        return {"id": "42"}
+
+    def cql(self, query):
+        self.calls.append(("search", query))
+        return {"results": [1]}
+
+    def append_page(self, page_id, content):
+        self.calls.append(("append", page_id, content))
+
+
+def test_create_page(monkeypatch):
+    dummy = DummyConfluence()
+    monkeypatch.setattr(confluence_tools, "get_confluence_client", lambda: dummy)
+    result = confluence_tools.create_confluence_page(
+        space="TS", title="Title", body="Body"
+    )
+    assert result == "42"
+    assert dummy.calls == [("create", "TS", "Title", "Body")]
+
+
+def test_search(monkeypatch):
+    dummy = DummyConfluence()
+    monkeypatch.setattr(confluence_tools, "get_confluence_client", lambda: dummy)
+    result = confluence_tools.search_confluence(query="hello")
+    assert result == {"results": [1]}
+    assert dummy.calls == [("search", "siteSearch ~ 'hello'")]
+
+
+def test_append_page(monkeypatch):
+    dummy = DummyConfluence()
+    monkeypatch.setattr(confluence_tools, "get_confluence_client", lambda: dummy)
+    msg = confluence_tools.append_to_confluence_page(page_id="1", content="content")
+    assert msg == "content appended"
+    assert dummy.calls == [("append", "1", "content")]


### PR DESCRIPTION
## Summary
- add Confluence helper tools and expose them in package
- document new tools in Atlassian integration guide
- add tests for Confluence tools
- mark task 403 done

## Testing
- `black src tests`
- `flake8 src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68704cb2f904832a85ecb650122156c1