### PR TITLE
Implement Jira-Confluence linking tool

### DIFF
--- a/src/ticketsmith/__init__.py
+++ b/src/ticketsmith/__init__.py
@@ -13,6 +13,7 @@ from .confluence_tools import (
     search_confluence,
     append_to_confluence_page,
 )
+from .linking_tools import create_linked_issue_and_page
 from .atlassian_auth import (
     AtlassianAuthError,
     get_confluence_client,
@@ -40,4 +41,5 @@ __all__ = [
     "create_confluence_page",
     "search_confluence",
     "append_to_confluence_page",
+    "create_linked_issue_and_page",
 ]

--- a/src/ticketsmith/confluence_tools.py
+++ b/src/ticketsmith/confluence_tools.py
@@ -6,10 +6,14 @@ from .tools import tool
 from .atlassian_auth import get_confluence_client
 
 CREATE_DESC = (
-    "Create a Confluence page in the given space with the provided title and body."
+    "Create a Confluence page in the given space with the provided "
+    "title and body."  # noqa: E501
 )
 
-SEARCH_DESC = "Search Confluence using the siteSearch field to find relevant pages."
+SEARCH_DESC = (
+    "Search Confluence using the siteSearch field to find relevant "
+    "pages."  # noqa: E501
+)
 
 APPEND_DESC = "Append content to an existing Confluence page by ID."
 

--- a/src/ticketsmith/linking_tools.py
+++ b/src/ticketsmith/linking_tools.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import os
+from typing import Dict
+
+from .tools import tool
+from .jira_tools import create_jira_issue, add_jira_comment
+from .confluence_tools import create_confluence_page
+
+
+LINK_DESC = (
+    "Create a Jira issue and Confluence page with reciprocal links. "
+    "Provide project key, summary, description, issue type, Confluence space, "
+    "title, and body."
+)
+
+
+@tool(name="create_linked_issue_and_page", description=LINK_DESC)
+def create_linked_issue_and_page(
+    project_key: str,
+    summary: str,
+    description: str,
+    issue_type: str,
+    space: str,
+    title: str,
+    body: str,
+) -> Dict[str, str]:
+    """Create linked Jira issue and Confluence page.
+
+    Args:
+        project_key: Jira project key.
+        summary: Issue summary.
+        description: Issue description.
+        issue_type: Type of Jira issue (e.g., Task).
+        space: Confluence space key.
+        title: Title for the Confluence page.
+        body: Initial page body in storage format.
+
+    Returns:
+        Dictionary with ``issue_key`` and ``page_id``.
+    """
+
+    base_url = os.environ.get("ATLASSIAN_BASE_URL", "").rstrip("/")
+    if not base_url:
+        raise RuntimeError("ATLASSIAN_BASE_URL is required")
+
+    try:
+        issue_key = create_jira_issue(
+            project_key=project_key,
+            summary=summary,
+            description=description,
+            issue_type=issue_type,
+        )
+    except Exception as exc:  # noqa: BLE001
+        raise RuntimeError(f"Failed to create Jira issue: {exc}") from exc
+
+    issue_url = f"{base_url}/browse/{issue_key}"
+    body_with_link = body + (
+        "<p>Related Jira issue: " f"<a href='{issue_url}'>{issue_key}</a></p>"
+    )
+
+    try:
+        page_id = create_confluence_page(
+            space=space,
+            title=title,
+            body=body_with_link,
+        )
+    except Exception as exc:  # noqa: BLE001
+        raise RuntimeError(f"Failed to create Confluence page: {exc}") from exc
+
+    page_url = f"{base_url}/wiki/spaces/{space}/pages/{page_id}"
+
+    try:
+        add_jira_comment(
+            issue_key=issue_key,
+            comment=f"Confluence page: {page_url}",
+        )
+    except Exception as exc:  # noqa: BLE001
+        raise RuntimeError(f"Failed to comment on Jira issue: {exc}") from exc
+
+    return {"issue_key": issue_key, "page_id": page_id}

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -343,7 +343,7 @@
     - 402
     - 403
   priority: 3
-  status: "pending"
+  status: "done"
   command: null
   task_id: "TOOL-LINKING-001"
   area: "Development"

--- a/tests/test_confluence_tools.py
+++ b/tests/test_confluence_tools.py
@@ -19,7 +19,11 @@ class DummyConfluence:
 
 def test_create_page(monkeypatch):
     dummy = DummyConfluence()
-    monkeypatch.setattr(confluence_tools, "get_confluence_client", lambda: dummy)
+    monkeypatch.setattr(
+        confluence_tools,
+        "get_confluence_client",
+        lambda: dummy,
+    )
     result = confluence_tools.create_confluence_page(
         space="TS", title="Title", body="Body"
     )
@@ -29,7 +33,11 @@ def test_create_page(monkeypatch):
 
 def test_search(monkeypatch):
     dummy = DummyConfluence()
-    monkeypatch.setattr(confluence_tools, "get_confluence_client", lambda: dummy)
+    monkeypatch.setattr(
+        confluence_tools,
+        "get_confluence_client",
+        lambda: dummy,
+    )
     result = confluence_tools.search_confluence(query="hello")
     assert result == {"results": [1]}
     assert dummy.calls == [("search", "siteSearch ~ 'hello'")]
@@ -37,7 +45,14 @@ def test_search(monkeypatch):
 
 def test_append_page(monkeypatch):
     dummy = DummyConfluence()
-    monkeypatch.setattr(confluence_tools, "get_confluence_client", lambda: dummy)
-    msg = confluence_tools.append_to_confluence_page(page_id="1", content="content")
+    monkeypatch.setattr(
+        confluence_tools,
+        "get_confluence_client",
+        lambda: dummy,
+    )
+    msg = confluence_tools.append_to_confluence_page(
+        page_id="1",
+        content="content",
+    )
     assert msg == "content appended"
     assert dummy.calls == [("append", "1", "content")]

--- a/tests/test_linking_tools.py
+++ b/tests/test_linking_tools.py
@@ -1,0 +1,59 @@
+from ticketsmith import linking_tools
+
+
+class DummyTools:
+    def __init__(self):
+        self.calls = []
+
+
+def test_create_linked(monkeypatch):
+    def fake_create_jira_issue(**kwargs):
+        dummy.calls.append(("create_issue", kwargs))
+        return "TST-1"
+
+    def fake_create_confluence_page(space, title, body):
+        dummy.calls.append(("create_page", space, title, body))
+        return "42"
+
+    def fake_add_jira_comment(issue_key, comment):
+        dummy.calls.append(("comment", issue_key, comment))
+        return "ok"
+
+    dummy = DummyTools()
+    monkeypatch.setattr(
+        linking_tools,
+        "create_jira_issue",
+        fake_create_jira_issue,
+    )
+    monkeypatch.setattr(
+        linking_tools,
+        "create_confluence_page",
+        fake_create_confluence_page,
+    )
+    monkeypatch.setattr(
+        linking_tools,
+        "add_jira_comment",
+        fake_add_jira_comment,
+    )
+    monkeypatch.setenv("ATLASSIAN_BASE_URL", "https://example.atlassian.net")
+
+    result = linking_tools.create_linked_issue_and_page(
+        project_key="TST",
+        summary="s",
+        description="d",
+        issue_type="Task",
+        space="DOC",
+        title="T",
+        body="B",
+    )
+
+    assert result == {"issue_key": "TST-1", "page_id": "42"}
+    issue_url = "https://example.atlassian.net/browse/TST-1"
+    page_url = "https://example.atlassian.net/wiki/spaces/DOC/pages/42"
+    assert (
+        "create_page",
+        "DOC",
+        "T",
+        "B<p>Related Jira issue: <a href='" + issue_url + "'>TST-1</a></p>",
+    ) in dummy.calls
+    assert ("comment", "TST-1", f"Confluence page: {page_url}") in dummy.calls


### PR DESCRIPTION
## Summary
- implement `create_linked_issue_and_page` tool
- export new tool and add tests
- update Confluence tool docstrings
- fix long lines in tests
- mark Task 404 done in `tasks.yaml`

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68704ed228e8832aa7bf4fa45196bcc0