### PR TITLE
Add RAG architecture docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ For a high-level architectural overview, see [Architecture Blueprint](docs/ARCHI
 See [Core Agent Loop](docs/CORE_AGENT_LOOP.md) for implementation details of the ReAct loop.
 See [LLM Model Selection](docs/LLM_MODEL_SELECTION.md) for the selected models and Confluence matrix.
 For details on Atlassian API usage and authentication, see [Atlassian Integration](docs/ATLASSIAN_INTEGRATION.md).
+See [RAG Architecture](docs/RAG_ARCHITECTURE.md) for the ingestion and retrieval pipeline.
 
 ## Self-Hosted Inference Server
 

--- a/docs/RAG_ARCHITECTURE.md
+++ b/docs/RAG_ARCHITECTURE.md
@@ -1,0 +1,36 @@
+# Retrieval-Augmented Generation (RAG) Architecture
+
+This document details how TicketSmith ingests knowledge sources and uses them at run time.
+
+## Pipeline Diagram
+
+```mermaid
+graph LR
+    A["Data Ingestion\nConfluence Spaces"] --> B["Chunking"]
+    B --> C["Embedding\nnomic-embed-text"]
+    C --> D["Indexing\npgvector"]
+    subgraph Retrieval
+        Q["User Query"] --> F["Query Embedding"]
+        F --> D
+        D --> G["Top-k Chunks"]
+    end
+    G --> H["Prompt Augmentation"]
+    H --> I["Generation"]
+```
+
+## Data Sources
+
+Content is pulled from the team's Confluence spaces such as **Engineering** and **Product**. Ingestion jobs may target additional spaces by configuration.
+
+## Chunking Strategy
+
+Documents are split with LangChain's `RecursiveCharacterTextSplitter` using a 1000 token size and 200 token overlap. This keeps related sentences together and improves recall.
+
+## Embedding Model
+
+The [`nomic-embed-text`](https://github.com/nomic-ai/nomic) model generates vector representations for each chunk. It offers a balance of quality and open licensing for self-hosted deployments.
+
+## Vector Database
+
+Embeddings and associated metadata are stored in PostgreSQL via the [`pgvector`](https://github.com/pgvector/pgvector) extension. This allows efficient similarity search without adding an extra service.
+

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -367,7 +367,7 @@
   dependencies:
     - 104
   priority: 1
-  status: "pending"
+  status: "done"
   command: null
   task_id: "RAG-ARCH-001"
   area: "Architecture"


### PR DESCRIPTION
## Summary
- document ingestion to retrieval pipeline in new RAG Architecture page
- link to the RAG doc from README
- mark the RAG architecture task as done

## Testing
- `black .`
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687056ded018832abef5612089f21e40