### PR TITLE
Implement Confluence ingestion pipeline

### DIFF
--- a/src/ticketsmith/__init__.py
+++ b/src/ticketsmith/__init__.py
@@ -13,6 +13,7 @@ from .confluence_tools import (
     search_confluence,
     append_to_confluence_page,
 )
+from .confluence_ingest import ConfluenceIngestor, extract_text, chunk_text
 from .linking_tools import create_linked_issue_and_page
 from .atlassian_auth import (
     AtlassianAuthError,
@@ -42,4 +43,7 @@ __all__ = [
     "search_confluence",
     "append_to_confluence_page",
     "create_linked_issue_and_page",
+    "ConfluenceIngestor",
+    "extract_text",
+    "chunk_text",
 ]

--- a/src/ticketsmith/confluence_ingest.py
+++ b/src/ticketsmith/confluence_ingest.py
@@ -1,0 +1,88 @@
+"""Utilities for ingesting Confluence pages into text chunks."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Dict, List
+
+from bs4 import BeautifulSoup
+
+from .atlassian_auth import get_confluence_client
+from .confluence_tools import search_confluence
+
+
+def extract_text(html: str) -> str:
+    """Return plain text from Confluence storage format."""
+    soup = BeautifulSoup(html, "html.parser")
+    return soup.get_text(separator=" ", strip=True)
+
+
+def chunk_text(text: str, size: int = 1000, overlap: int = 200) -> List[str]:
+    """Split ``text`` into overlapping chunks."""
+    chunks: List[str] = []
+    start = 0
+    while start < len(text):
+        end = start + size
+        chunks.append(text[start:end])
+        start += size - overlap
+    return chunks
+
+
+class ConfluenceIngestor:
+    """Fetch pages from Confluence and maintain a local index."""
+
+    def __init__(self, index_path: str) -> None:
+        self.index_path = index_path
+        self._load()
+        self.client = get_confluence_client()
+
+    def _load(self) -> None:
+        if os.path.exists(self.index_path):
+            with open(self.index_path, "r", encoding="utf-8") as f:
+                self.index: Dict[str, Dict[str, object]] = json.load(f)
+        else:
+            self.index = {}
+
+    def _save(self) -> None:
+        with open(self.index_path, "w", encoding="utf-8") as f:
+            json.dump(self.index, f)
+
+    def sync(self, query: str) -> List[Dict[str, object]]:
+        """Fetch updated pages matching ``query`` and update the index."""
+        results = search_confluence(query).get("results", [])
+        seen: set[str] = set()
+        for res in results:
+            page_id = str(res.get("id") or res.get("content", {}).get("id"))
+            if not page_id:
+                continue
+            seen.add(page_id)
+            page = self.client.get_page_by_id(
+                page_id,
+                expand="body.storage,version",
+            )
+            version = page.get("version", {}).get("number", 0)
+            stored = self.index.get(page_id, {})
+            if stored.get("version") == version:
+                continue
+            text = extract_text(
+                page.get("body", {}).get("storage", {}).get("value", "")
+            )
+            chunks = chunk_text(text)
+            self.index[page_id] = {"version": version, "chunks": chunks}
+        for pid in list(self.index):
+            if pid not in seen:
+                del self.index[pid]
+        self._save()
+        all_chunks = []
+        for pid, data in self.index.items():
+            for i, chunk in enumerate(data["chunks"]):
+                all_chunks.append(
+                    {
+                        "page_id": pid,
+                        "version": data["version"],
+                        "index": i,
+                        "text": chunk,
+                    }
+                )
+        return all_chunks

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -390,7 +390,7 @@
     - 501
     - 403
   priority: 2
-  status: "pending"
+  status: "done"
   command: null
   task_id: "RAG-DEV-001"
   area: "Development"

--- a/tests/test_confluence_ingest.py
+++ b/tests/test_confluence_ingest.py
@@ -1,0 +1,46 @@
+from ticketsmith.confluence_ingest import ConfluenceIngestor
+
+
+class DummyConfluence:
+    def __init__(self, body="<p>Hello</p>", version=1):
+        self.body = body
+        self.version = version
+        self.calls = []
+
+    def get_page_by_id(self, page_id, expand=None):
+        self.calls.append((page_id, expand))
+        return {
+            "body": {"storage": {"value": self.body}},
+            "version": {"number": self.version},
+        }
+
+
+def test_sync_new_page(tmp_path, monkeypatch):
+    dummy = DummyConfluence()
+    monkeypatch.setattr(
+        "ticketsmith.confluence_ingest.get_confluence_client", lambda: dummy
+    )
+    monkeypatch.setattr(
+        "ticketsmith.confluence_ingest.search_confluence",
+        lambda q: {"results": [{"content": {"id": "1"}}]},
+    )
+    ing = ConfluenceIngestor(str(tmp_path / "index.json"))
+    chunks = ing.sync("query")
+    assert chunks[0]["text"] == "Hello"
+    assert dummy.calls
+
+
+def test_sync_delete(tmp_path, monkeypatch):
+    dummy = DummyConfluence()
+    monkeypatch.setattr(
+        "ticketsmith.confluence_ingest.get_confluence_client", lambda: dummy
+    )
+    results = {"results": [{"content": {"id": "1"}}]}
+    monkeypatch.setattr(
+        "ticketsmith.confluence_ingest.search_confluence", lambda q: results
+    )
+    ing = ConfluenceIngestor(str(tmp_path / "index.json"))
+    ing.sync("query")
+    results["results"] = []
+    chunks = ing.sync("query")
+    assert chunks == []


### PR DESCRIPTION
## Summary
- add `ConfluenceIngestor` for fetching pages via `search_confluence`
- support text extraction and chunking
- track versions and handle deleted pages
- expose new functions in package
- test ingestion logic
- mark Task 502 as done

## Testing
- `black -q src tests`
- `flake8 src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687062626464832a9773473d950efe26