### PR TITLE
Implement retrieval tool

### DIFF
--- a/src/ticketsmith/__init__.py
+++ b/src/ticketsmith/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .core_agent import CoreAgent
 from .memory import ConversationBuffer, SimpleVectorStore
 from .planning import StepPlanner, PlanResult
@@ -14,6 +16,7 @@ from .confluence_tools import (
     append_to_confluence_page,
 )
 from .confluence_ingest import ConfluenceIngestor, extract_text, chunk_text
+from .knowledge_base import knowledge_base_search, retrieve_relevant_chunks
 from .linking_tools import create_linked_issue_and_page
 from .atlassian_auth import (
     AtlassianAuthError,
@@ -46,4 +49,6 @@ __all__ = [
     "ConfluenceIngestor",
     "extract_text",
     "chunk_text",
+    "knowledge_base_search",
+    "retrieve_relevant_chunks",
 ]

--- a/src/ticketsmith/knowledge_base.py
+++ b/src/ticketsmith/knowledge_base.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from .vector_store import QdrantVectorStore
+from .tools import tool
+
+
+# Default collection name for Qdrant
+_DEFAULT_COLLECTION = "ticketsmith_docs"
+# The global vector store instance can be patched in tests
+vector_store = QdrantVectorStore(_DEFAULT_COLLECTION)
+
+
+def retrieve_relevant_chunks(query: str, top_k: int = 5) -> str:
+    """Return relevant knowledge base chunks for ``query``.
+
+    Args:
+        query: Natural language query string.
+        top_k: Number of similar chunks to retrieve.
+
+    Returns:
+        Formatted string with chunk text and metadata.
+    """
+    results: List[Dict[str, Any]] = vector_store.similarity_search(
+        query,
+        top_k=top_k,
+    )
+    lines = []
+    for res in results:
+        meta = {k: v for k, v in res.items() if k not in {"text", "score"}}
+        meta_str = ", ".join(f"{k}={v}" for k, v in meta.items())
+        line = res.get("text", "")
+        if meta_str:
+            line = f"[{meta_str}] {line}"
+        lines.append(line)
+    return "\n".join(lines)
+
+
+@tool(
+    name="knowledge_base_search",
+    description=(
+        "Search the internal knowledge base for relevant document chunks"
+        " and return them formatted for prompting."
+    ),
+)
+def knowledge_base_search(query: str) -> str:
+    """LangChain tool wrapper for :func:`retrieve_relevant_chunks`."""
+    return retrieve_relevant_chunks(query)

--- a/src/ticketsmith/vector_store.py
+++ b/src/ticketsmith/vector_store.py
@@ -58,7 +58,7 @@ class QdrantVectorStore:
         self._ensure_collection(len(vectors[0]))
         payloads = []
         for doc in docs_list:
-            payloads.append({k: v for k, v in doc.items() if k != "text"})
+            payloads.append(dict(doc))
         points = [
             rest.PointStruct(id=self._next_id + i, vector=vec, payload=pl)
             for i, (vec, pl) in enumerate(zip(vectors, payloads))

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -436,7 +436,7 @@
     - 503
     - 204
   priority: 2
-  status: "pending"
+  status: "done"
   command: null
   task_id: "RAG-DEV-002"
   area: "Development"

--- a/tests/test_knowledge_base.py
+++ b/tests/test_knowledge_base.py
@@ -1,0 +1,29 @@
+from ticketsmith.vector_store import QdrantVectorStore
+from ticketsmith import knowledge_base_search, retrieve_relevant_chunks
+import ticketsmith.knowledge_base as kb
+
+
+def ascii_embed(text: str) -> list[float]:
+    return [float(ord(text[0])), float(ord(text[-1]))]
+
+
+def test_retrieve_relevant_chunks(monkeypatch):
+    store = QdrantVectorStore("test", embed_fn=ascii_embed)
+    store.add_documents(
+        [
+            {"text": "hello world", "page_id": "1", "index": 0},
+            {"text": "goodbye", "page_id": "2", "index": 0},
+        ]
+    )
+    monkeypatch.setattr(kb, "vector_store", store)
+    output = retrieve_relevant_chunks("hello")
+    assert "hello world" in output
+    assert "page_id=1" in output
+
+
+def test_tool_wrapper(monkeypatch):
+    store = QdrantVectorStore("test2", embed_fn=ascii_embed)
+    store.add_documents([{"text": "alpha", "page_id": "a", "index": 0}])
+    monkeypatch.setattr(kb, "vector_store", store)
+    result = knowledge_base_search(query="alpha")
+    assert "alpha" in result


### PR DESCRIPTION
## Summary
- implement knowledge base search tool for RAG retrieval
- expose retrieval helpers in package
- store chunk text in vector store payloads
- add tests for retrieval tool
- mark RAG-DEV-002 task as done

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871d40d6b9c832ab4c6c90e7e057664