### PR TITLE
Add evaluation dataset and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,7 @@ For scaling policies, blue-green deployments, and backup procedures, see
 Developers can run quantized models directly on their machines for quick
 experimentation. See [Local Inference with llama-cpp-python](docs/LOCAL_INFERENCE.md)
 for installation instructions and a sample script.
+
+## Evaluation Dataset
+
+A curated evaluation dataset lives in the [`evaluation_dataset`](evaluation_dataset/) directory. Each entry defines a user prompt, the expected output, and the context the agent should reference. Update the dataset and commit changes whenever new examples are added so automated evaluations remain reproducible.

--- a/evaluation_dataset/README.md
+++ b/evaluation_dataset/README.md
@@ -1,0 +1,10 @@
+# Evaluation Dataset
+
+This directory contains the curated evaluation dataset used for end-to-end agent tests. Each entry in `dataset.json` includes:
+
+- `id`: Unique numeric identifier.
+- `prompt`: Input question or instruction.
+- `expected_output`: The ideal answer or action produced by the agent.
+- `context`: Documents or other information the agent should rely on.
+
+Update the file whenever new examples are added. Changes should be committed to version control so tests always use the latest dataset.

--- a/evaluation_dataset/dataset.json
+++ b/evaluation_dataset/dataset.json
@@ -1,0 +1,26 @@
+[
+  {
+    "id": 1,
+    "prompt": "I can't log in. Please open a bug ticket in project ABC.",
+    "expected_output": "Issue created via create_jira_issue with project_key=ABC and issue_type='Bug'.",
+    "context": "Jira project ABC."
+  },
+  {
+    "id": 2,
+    "prompt": "Summarize Confluence page 12345 for me.",
+    "expected_output": "Short summary of page 12345 content.",
+    "context": "Text of Confluence page 12345."
+  },
+  {
+    "id": 3,
+    "prompt": "Link issue ABC-1 with a new Confluence page titled 'Fix steps'.",
+    "expected_output": "Page created and ABC-1 commented with the link.",
+    "context": "Issue ABC-1 exists, Confluence space TS."
+  },
+  {
+    "id": 4,
+    "prompt": "Move ABC-2 to In Review.",
+    "expected_output": "Issue ABC-2 transitioned to In Review.",
+    "context": "ABC-2 has valid In Review transition."
+  }
+]

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -578,7 +578,7 @@
   dependencies:
     - 101
   priority: 1
-  status: "pending"
+  status: "done"
   command: null
   task_id: "QA-DATA-001"
   area: "Testing"


### PR DESCRIPTION
## Summary
- create `evaluation_dataset` directory with JSON and README
- document dataset usage in the main README
- mark QA-DATA-001 complete in `tasks.yaml`
- dependencies installed to run tests

## Testing
- `black .`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871fbd33d0c832ab0172597e756a91f