### PR TITLE
Add LLM judge evaluation tool

### DIFF
--- a/scripts/run_evaluation.py
+++ b/scripts/run_evaluation.py
@@ -1,0 +1,31 @@
+"""Run LLM-judge evaluation across the dataset."""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+from ticketsmith.evaluation import evaluate_from_files
+
+
+def main() -> None:
+    """CLI entrypoint."""
+    parser = argparse.ArgumentParser(description="Evaluate agent outputs")
+    parser.add_argument("dataset", help="Path to evaluation dataset JSON")
+    parser.add_argument("outputs", help="Path to JSON file of agent outputs")
+    parser.add_argument("--model", default="gpt-4o", help="OpenAI model name")
+    parser.add_argument(
+        "--report",
+        default="report.json",
+        help="Output report file",
+    )
+    args = parser.parse_args()
+
+    scores = evaluate_from_files(args.dataset, args.outputs, model=args.model)
+    with open(args.report, "w", encoding="utf-8") as f:
+        json.dump(scores, f, indent=2)
+    print(json.dumps(scores, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/ticketsmith/evaluation.py
+++ b/src/ticketsmith/evaluation.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import json
+from typing import Dict, Iterable, List, Tuple
+
+import openai
+
+JUDGE_PROMPT = (
+    "You are a strict judge for AI assistants. "
+    "Score the candidate's answer on a scale of 1-5 for both relevance "
+    "and coherence. "
+    "Relevance measures how well the answer addresses the user's question. "
+    "Coherence measures how logically consistent and well-structured the "
+    "answer is. "
+    "Respond in JSON with keys 'relevance', 'coherence', and 'rationale'."
+)
+
+
+def score_answer(
+    question: str,
+    candidate: str,
+    truth: str,
+    model: str = "gpt-4o",
+) -> Dict[str, str | int]:
+    """Score a candidate answer with an LLM judge."""
+    messages = [
+        {"role": "system", "content": JUDGE_PROMPT},
+        {
+            "role": "user",
+            "content": (
+                f"Question: {question}\n"
+                f"Candidate answer: {candidate}\n"
+                f"Ground truth: {truth}"
+            ),
+        },
+    ]
+    response = openai.ChatCompletion.create(model=model, messages=messages)
+    content = response["choices"][0]["message"]["content"]
+    return json.loads(content)
+
+
+def evaluate_dataset(
+    dataset: Iterable[Tuple[str, str, str]],
+    model: str = "gpt-4o",
+) -> List[Dict[str, str | int]]:
+    """Run evaluation on an iterable of question, candidate, truth tuples."""
+    results: List[Dict[str, str | int]] = []
+    for question, candidate, truth in dataset:
+        results.append(score_answer(question, candidate, truth, model=model))
+    return results
+
+
+def aggregate_scores(
+    results: Iterable[Dict[str, int | str]],
+) -> Dict[str, float]:
+    """Compute average relevance and coherence from results."""
+    relevance = [r.get("relevance", 0) for r in results]
+    coherence = [r.get("coherence", 0) for r in results]
+    avg_rel = sum(relevance) / len(relevance) if relevance else 0.0
+    avg_coh = sum(coherence) / len(coherence) if coherence else 0.0
+    return {"avg_relevance": avg_rel, "avg_coherence": avg_coh}
+
+
+def evaluate_from_files(
+    dataset_path: str,
+    outputs_path: str,
+    model: str = "gpt-4o",
+) -> Dict[str, float]:
+    """Evaluate agent outputs loaded from files and aggregate scores."""
+    with open(dataset_path, "r", encoding="utf-8") as f:
+        dataset = json.load(f)
+    with open(outputs_path, "r", encoding="utf-8") as f:
+        outputs = {int(k): v for k, v in json.load(f).items()}
+
+    triples = [
+        (item["prompt"], outputs[item["id"]], item["expected_output"])
+        for item in dataset
+        if item["id"] in outputs
+    ]
+    results = evaluate_dataset(triples, model=model)
+    return aggregate_scores(results)

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -600,7 +600,7 @@
   dependencies:
     - 702
   priority: 2
-  status: "pending"
+  status: "done"
   command: null
   task_id: "QA-EVAL-001"
   area: "Testing"


### PR DESCRIPTION
## Summary
- add evaluation utilities that query an LLM judge for relevance and coherence
- provide CLI script to run evaluation and produce a report
- mark task 703 (QA-EVAL-001) as done
- tests pass

## Testing
- `flake8 src/ticketsmith/evaluation.py scripts/run_evaluation.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687200b41ea4832a8d520dae5db8799c