### PR TITLE
Add RAG evaluation suite

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ langgraph==0.0.10
 pydantic
 llama-cpp-python
 qdrant-client
+openai
 sentence-transformers
 pytest
 pytest-mock

--- a/scripts/run_evaluation.py
+++ b/scripts/run_evaluation.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import argparse
 import json
 
-from ticketsmith.evaluation import evaluate_from_files
+from ticketsmith.evaluation import evaluate_from_files, evaluate_rag_from_files
 
 
 def main() -> None:
@@ -19,9 +19,28 @@ def main() -> None:
         default="report.json",
         help="Output report file",
     )
+    parser.add_argument(
+        "--rag",
+        action="store_true",
+        help=(
+            "Run RAG triad evaluation (context relevance, groundedness, "
+            "answer relevance)"
+        ),
+    )
     args = parser.parse_args()
 
-    scores = evaluate_from_files(args.dataset, args.outputs, model=args.model)
+    if args.rag:
+        scores = evaluate_rag_from_files(
+            args.dataset,
+            args.outputs,
+            model=args.model,
+        )
+    else:
+        scores = evaluate_from_files(
+            args.dataset,
+            args.outputs,
+            model=args.model,
+        )
     with open(args.report, "w", encoding="utf-8") as f:
         json.dump(scores, f, indent=2)
     print(json.dumps(scores, indent=2))

--- a/src/ticketsmith/evaluation.py
+++ b/src/ticketsmith/evaluation.py
@@ -19,6 +19,19 @@ JUDGE_PROMPT = (
     "'rationale'."
 )
 
+# Additional prompt for RAG-specific evaluation
+RAG_JUDGE_PROMPT = (
+    "You are a strict judge for RAG systems. "
+    "Score the retrieved context and candidate answer on a scale of 1-5 for "
+    "context relevance, answer relevance, and groundedness. "
+    "Context relevance measures how well the provided context matches the "
+    "user's question. Answer relevance measures how well the candidate "
+    "answer addresses the question. Groundedness measures whether the "
+    "answer is supported by the context. Respond in JSON with keys "
+    "'context_relevance', 'answer_relevance', 'groundedness', and "
+    "'rationale'."
+)
+
 
 def score_answer(
     question: str,
@@ -48,6 +61,31 @@ def score_answer(
     return json.loads(content)
 
 
+def score_rag_answer(
+    question: str,
+    candidate: str,
+    retrieved_context: str,
+    truth: str,
+    model: str = "gpt-4o",
+) -> Dict[str, str | int]:
+    """Score a RAG answer with context using an LLM judge."""
+    messages = [
+        {"role": "system", "content": RAG_JUDGE_PROMPT},
+        {
+            "role": "user",
+            "content": (
+                f"Question: {question}\n"
+                f"Retrieved context: {retrieved_context}\n"
+                f"Candidate answer: {candidate}\n"
+                f"Ground truth: {truth}"
+            ),
+        },
+    ]
+    response = openai.ChatCompletion.create(model=model, messages=messages)
+    content = response["choices"][0]["message"]["content"]
+    return json.loads(content)
+
+
 def evaluate_dataset(
     dataset: Iterable[Tuple[str, str, str, str]],
     model: str = "gpt-4o",
@@ -67,6 +105,25 @@ def evaluate_dataset(
     return results
 
 
+def evaluate_rag_dataset(
+    dataset: Iterable[Tuple[str, str, str, str]],
+    model: str = "gpt-4o",
+) -> List[Dict[str, str | int]]:
+    """Run RAG evaluation on question, answer, context, and ground truth."""
+    results: List[Dict[str, str | int]] = []
+    for question, candidate, context, truth in dataset:
+        results.append(
+            score_rag_answer(
+                question,
+                candidate,
+                context,
+                truth,
+                model=model,
+            )
+        )
+    return results
+
+
 def aggregate_scores(
     results: Iterable[Dict[str, int | str]],
 ) -> Dict[str, float]:
@@ -80,6 +137,24 @@ def aggregate_scores(
     return {
         "avg_relevance": avg_rel,
         "avg_coherence": avg_coh,
+        "avg_groundedness": avg_ground,
+    }
+
+
+def aggregate_rag_scores(
+    results: Iterable[Dict[str, int | str]],
+) -> Dict[str, float]:
+    """Compute average context relevance, answer relevance, and "
+    "groundedness."""
+    context_rel = [r.get("context_relevance", 0) for r in results]
+    answer_rel = [r.get("answer_relevance", 0) for r in results]
+    grounded = [r.get("groundedness", 0) for r in results]
+    avg_ctx = sum(context_rel) / len(context_rel) if context_rel else 0.0
+    avg_ans = sum(answer_rel) / len(answer_rel) if answer_rel else 0.0
+    avg_ground = sum(grounded) / len(grounded) if grounded else 0.0
+    return {
+        "avg_context_relevance": avg_ctx,
+        "avg_answer_relevance": avg_ans,
         "avg_groundedness": avg_ground,
     }
 
@@ -107,3 +182,33 @@ def evaluate_from_files(
     ]
     results = evaluate_dataset(triples, model=model)
     return aggregate_scores(results)
+
+
+def evaluate_rag_from_files(
+    dataset_path: str,
+    outputs_path: str,
+    model: str = "gpt-4o",
+) -> Dict[str, float]:
+    """Evaluate RAG outputs loaded from files and aggregate scores."""
+    with open(dataset_path, "r", encoding="utf-8") as f:
+        dataset = json.load(f)
+    with open(outputs_path, "r", encoding="utf-8") as f:
+        outputs = {int(k): v for k, v in json.load(f).items()}
+
+    rows = []
+    for item in dataset:
+        out = outputs.get(item["id"])
+        if not out:
+            continue
+        answer = out.get("answer") if isinstance(out, dict) else out
+        context = out.get("context", "") if isinstance(out, dict) else ""
+        rows.append(
+            (
+                item["prompt"],
+                answer,
+                context,
+                item["expected_output"],
+            )
+        )
+    results = evaluate_rag_dataset(rows, model=model)
+    return aggregate_rag_scores(results)

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -645,7 +645,7 @@
     - 504
     - 703
   priority: 2
-  status: "pending"
+  status: "done"
   command: null
   task_id: "QA-EVAL-003"
   area: "Testing"

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -1,0 +1,12 @@
+from ticketsmith.evaluation import aggregate_rag_scores
+
+
+def test_aggregate_rag_scores():
+    results = [
+        {"context_relevance": 5, "answer_relevance": 4, "groundedness": 3},
+        {"context_relevance": 3, "answer_relevance": 5, "groundedness": 4},
+    ]
+    agg = aggregate_rag_scores(results)
+    assert agg["avg_context_relevance"] == 4.0
+    assert agg["avg_answer_relevance"] == 4.5
+    assert agg["avg_groundedness"] == 3.5


### PR DESCRIPTION
## Summary
- implement RAG-specific evaluation metrics
- extend evaluation script with `--rag` option
- add `openai` dependency
- mark QA-EVAL-003 task as done
- test aggregation logic for new metrics

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68720979712c832a97fc93df20493a21