### PR TITLE
Add evaluation metrics export

### DIFF
--- a/docs/QUALITY_MONITORING.md
+++ b/docs/QUALITY_MONITORING.md
@@ -1,0 +1,17 @@
+# Quality Monitoring
+
+This document describes how evaluation scores produced by the LLM judge are exported to Prometheus and visualized in Grafana.
+
+## Prometheus Metrics
+
+The evaluation framework publishes a gauge metric `ticketsmith_evaluation_score` with a `metric` label for each score such as `avg_relevance` and `avg_groundedness`. The metrics server can be started with `start_metrics_server()` and will expose these values at `/metrics`.
+
+## Grafana Dashboards
+
+Configure Prometheus as a data source in Grafana and create panels for the evaluation metric. Example query:
+
+```
+ticketsmith_evaluation_score{metric="avg_relevance"}
+```
+
+Add alert rules to notify the team when scores drop below acceptable thresholds, e.g. relevance < 3.0. This enables rapid detection of regressions in model quality.

--- a/scripts/run_evaluation.py
+++ b/scripts/run_evaluation.py
@@ -6,6 +6,7 @@ import argparse
 import json
 
 from ticketsmith.evaluation import evaluate_from_files, evaluate_rag_from_files
+from ticketsmith.metrics import start_metrics_server
 
 
 def main() -> None:
@@ -28,6 +29,7 @@ def main() -> None:
         ),
     )
     args = parser.parse_args()
+    start_metrics_server()
 
     if args.rag:
         scores = evaluate_rag_from_files(

--- a/src/ticketsmith/__init__.py
+++ b/src/ticketsmith/__init__.py
@@ -18,7 +18,7 @@ from .confluence_tools import (
 from .confluence_ingest import ConfluenceIngestor, extract_text, chunk_text
 from .knowledge_base import knowledge_base_search, retrieve_relevant_chunks
 from .linking_tools import create_linked_issue_and_page
-from .metrics import start_metrics_server
+from .metrics import start_metrics_server, record_evaluation_scores
 from .cost_tracking import chat_completion_with_tracking
 from .atlassian_auth import (
     AtlassianAuthError,
@@ -54,5 +54,6 @@ __all__ = [
     "knowledge_base_search",
     "retrieve_relevant_chunks",
     "start_metrics_server",
+    "record_evaluation_scores",
     "chat_completion_with_tracking",
 ]

--- a/src/ticketsmith/evaluation.py
+++ b/src/ticketsmith/evaluation.py
@@ -5,7 +5,12 @@ from typing import Dict, Iterable, List, Tuple
 
 from .cost_tracking import chat_completion_with_tracking
 
-from .metrics import ERROR_COUNT, REQUEST_LATENCY, record_token_usage
+from .metrics import (
+    ERROR_COUNT,
+    REQUEST_LATENCY,
+    record_token_usage,
+    record_evaluation_scores,
+)
 
 JUDGE_PROMPT = (
     "You are a strict judge for AI assistants. "
@@ -201,7 +206,9 @@ def evaluate_from_files(
         if item["id"] in outputs
     ]
     results = evaluate_dataset(triples, model=model)
-    return aggregate_scores(results)
+    scores = aggregate_scores(results)
+    record_evaluation_scores(scores)
+    return scores
 
 
 def evaluate_rag_from_files(
@@ -231,4 +238,6 @@ def evaluate_rag_from_files(
             )
         )
     results = evaluate_rag_dataset(rows, model=model)
-    return aggregate_rag_scores(results)
+    scores = aggregate_rag_scores(results)
+    record_evaluation_scores(scores)
+    return scores

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -808,7 +808,7 @@
     - 705
     - 804
   priority: 3
-  status: "pending"
+  status: "done"
   command: null
   task_id: "MONITOR-AIQA-001"
   area: "Monitoring"


### PR DESCRIPTION
## Summary
- record evaluation scores using a new Prometheus gauge
- expose helper `record_evaluation_scores`
- publish metrics from evaluation utilities and CLI
- document Grafana monitoring for evaluation scores
- mark MONITOR-AIQA-001 as done

## Testing
- `flake8 src scripts`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68722f3a99b0832a94b6f9a5224832b6