### PR TITLE
Implement PII redaction and incident response

### DIFF
--- a/docs/INCIDENT_RESPONSE.md
+++ b/docs/INCIDENT_RESPONSE.md
@@ -1,0 +1,11 @@
+# PII Incident Response Procedures
+
+This document outlines the steps to follow when Personally Identifiable Information (PII) is detected in logs or anywhere in the system.
+
+1. **Detection** – Automated scanning with the PII detection pipeline raises an alert if sensitive data is found.
+2. **Containment** – Immediately restrict access to affected logs or data stores and rotate any exposed credentials.
+3. **Notification** – Notify the Security Lead and legal/compliance teams. If required, inform impacted users and regulatory bodies.
+4. **Eradication** – Remove the PII from all locations. Verify that log processors are redacting future occurrences.
+5. **Postmortem** – Document the incident, root cause, and remediation steps in Confluence.
+
+Following this playbook satisfies the escalation plan described in task SEC-PII-001.

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ opentelemetry-exporter-otlp
 opentelemetry-instrumentation-flask
 opentelemetry-instrumentation-requests
 prometheus-client
+scrubadub

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -852,7 +852,7 @@
   dependencies:
     - 201
   priority: 1
-  status: "pending"
+  status: "done"
   command: null
   task_id: "SEC-PII-001"
   area: "Security"

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,4 +1,9 @@
-from ticketsmith.security import sanitize_input, GuardrailModel, parse_args
+from ticketsmith.security import (
+    GuardrailModel,
+    parse_args,
+    redact_pii,
+    sanitize_input,
+)
 from ticketsmith.core_agent import CoreAgent
 import pytest
 
@@ -8,6 +13,18 @@ def test_sanitize_input_redacts():
     sanitized = sanitize_input(text)
     assert "shutdown" not in sanitized.lower()
     assert "[REDACTED]" in sanitized
+
+
+def test_sanitize_input_removes_pii():
+    text = "Contact me at john@example.com"
+    sanitized = sanitize_input(text)
+    assert "john@example.com" not in sanitized
+
+
+def test_redact_pii_from_dict():
+    data = {"email": "john@example.com", "name": "Alice"}
+    redacted = redact_pii(data)
+    assert "john@example.com" not in str(redacted)
 
 
 def test_guardrail_blocks_suspicious():


### PR DESCRIPTION
## Summary
- integrate scrubadub for PII detection and redaction
- sanitize log events using new structlog processor
- document PII incident response procedures
- update task SEC-PII-001 as done
- add tests for new security utilities

## Testing
- `flake8 src/ticketsmith/security.py src/ticketsmith/logging_config.py tests/test_security.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687237bf3630832abe9d2094c0c059b0