### PR TITLE
Implement MkDocs setup and add module docstrings

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,24 @@
+name: Deploy Docs
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          pip install mkdocs mkdocs-material mkdocstrings[python]
+      - name: Build site
+        run: mkdocs build
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: site

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,3 @@
+# TicketSmith
+
+Welcome to the TicketSmith developer documentation. Use the navigation to explore architecture overviews, setup guides, and API references automatically generated from the source code.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,19 @@
+site_name: TicketSmith Documentation
+site_url: https://example.com
+repo_url: https://github.com/example/ticketsmith
+theme:
+  name: material
+plugins:
+  - search
+  - mkdocstrings:
+      handlers:
+        python:
+          setup_commands:
+            - import sys; sys.path.append('src')
+nav:
+  - Home: index.md
+  - Architecture: ARCHITECTURE_BLUEPRINT.md
+  - Developer Guide:
+      - Core Agent Loop: CORE_AGENT_LOOP.md
+      - Atlassian Integration: ATLASSIAN_INTEGRATION.md
+      - RAG Architecture: RAG_ARCHITECTURE.md

--- a/src/ticketsmith/__init__.py
+++ b/src/ticketsmith/__init__.py
@@ -1,3 +1,5 @@
+"""TicketSmith package providing core agent and utilities."""
+
 from __future__ import annotations
 
 from .core_agent import CoreAgent

--- a/src/ticketsmith/atlassian_auth.py
+++ b/src/ticketsmith/atlassian_auth.py
@@ -1,3 +1,5 @@
+"""Authentication helpers for Atlassian APIs."""
+
 from __future__ import annotations
 
 import os

--- a/src/ticketsmith/cli.py
+++ b/src/ticketsmith/cli.py
@@ -1,3 +1,5 @@
+"""Command line interface for running the agent."""
+
 from __future__ import annotations
 
 import click

--- a/src/ticketsmith/confluence_tools.py
+++ b/src/ticketsmith/confluence_tools.py
@@ -1,3 +1,5 @@
+"""Utilities for interacting with Confluence."""
+
 from __future__ import annotations
 
 from requests import RequestException

--- a/src/ticketsmith/core_agent.py
+++ b/src/ticketsmith/core_agent.py
@@ -1,3 +1,5 @@
+"""Core ReAct agent implementation."""
+
 from __future__ import annotations
 
 import re

--- a/src/ticketsmith/cost_tracking.py
+++ b/src/ticketsmith/cost_tracking.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Wrapper functions for LLM API calls with cost tracking."""
+
+from __future__ import annotations
 
 from typing import Any, Dict, List
 

--- a/src/ticketsmith/evaluation.py
+++ b/src/ticketsmith/evaluation.py
@@ -1,3 +1,5 @@
+"""Tools for automated evaluation of RAG responses."""
+
 from __future__ import annotations
 
 import json

--- a/src/ticketsmith/jira_tools.py
+++ b/src/ticketsmith/jira_tools.py
@@ -1,3 +1,5 @@
+"""Helper functions for interacting with Jira."""
+
 from __future__ import annotations
 
 from requests import RequestException

--- a/src/ticketsmith/knowledge_base.py
+++ b/src/ticketsmith/knowledge_base.py
@@ -1,3 +1,5 @@
+"""Simple question-answering knowledge base utilities."""
+
 from __future__ import annotations
 
 from typing import Any, Dict, List

--- a/src/ticketsmith/linking_tools.py
+++ b/src/ticketsmith/linking_tools.py
@@ -1,3 +1,5 @@
+"""Link Jira issues with Confluence pages."""
+
 from __future__ import annotations
 
 import os

--- a/src/ticketsmith/logging_config.py
+++ b/src/ticketsmith/logging_config.py
@@ -1,3 +1,5 @@
+"""Logging helpers with trace context."""
+
 import logging
 
 import structlog

--- a/src/ticketsmith/memory.py
+++ b/src/ticketsmith/memory.py
@@ -1,3 +1,5 @@
+"""In-memory conversation buffer and embedding store."""
+
 from __future__ import annotations
 
 import json

--- a/src/ticketsmith/metrics.py
+++ b/src/ticketsmith/metrics.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
+"""Prometheus metrics for TicketSmith."""
 
-"""Prometheus metrics for Ticketsmith."""
+from __future__ import annotations
 
 from typing import Any, Dict
 import os

--- a/src/ticketsmith/planning.py
+++ b/src/ticketsmith/planning.py
@@ -1,3 +1,5 @@
+"""Simple planner utilities."""
+
 from __future__ import annotations
 
 import re

--- a/src/ticketsmith/token_auth.py
+++ b/src/ticketsmith/token_auth.py
@@ -1,3 +1,5 @@
+"""Token validation helpers for tool access."""
+
 from __future__ import annotations
 
 import json

--- a/src/ticketsmith/tools.py
+++ b/src/ticketsmith/tools.py
@@ -1,3 +1,5 @@
+"""Utility classes and decorators for tool execution."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/src/ticketsmith/tracing.py
+++ b/src/ticketsmith/tracing.py
@@ -1,3 +1,5 @@
+"""Configure OpenTelemetry tracing and instrumentation."""
+
 from __future__ import annotations
 
 from opentelemetry import trace

--- a/src/ticketsmith/vector_store.py
+++ b/src/ticketsmith/vector_store.py
@@ -1,3 +1,5 @@
+"""Interface to Qdrant vector store."""
+
 from __future__ import annotations
 
 from typing import Any, Callable, Dict, Iterable, List, Optional

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -972,7 +972,7 @@
     - 403
     - 501
   priority: 2
-  status: "pending"
+  status: "done"
   command: "mkdocs build"
   task_id: "DOCS-DEV-001"
   area: "Documentation"


### PR DESCRIPTION
## Summary
- create `mkdocs.yml` and an index page
- add GitHub Actions workflow for docs deployment
- add module-level docstrings across the codebase
- mark documentation task DOCS-DEV-001 as done

## Testing
- `flake8`
- `black --check src`
- `pytest -q`
- `mkdocs build -q`


------
https://chatgpt.com/codex/tasks/task_e_6872e64a004c832aa3ba752b5fe4afdc