### PR TITLE
Add runbooks and escalation docs

### DIFF
--- a/docs/handoff/COST_ALERT_RUNBOOK.md
+++ b/docs/handoff/COST_ALERT_RUNBOOK.md
@@ -1,0 +1,12 @@
+# Cost Alert Runbook
+
+This runbook outlines the steps to take when the cloud cost alert fires.
+
+1. **Identify Source** – Review the alert details in the monitoring dashboard to determine which service triggered the cost spike.
+2. **Stop the Bleeding** – If costs are rapidly increasing due to a runaway process, scale down or pause the offending service immediately.
+3. **Notify Stakeholders** – Inform the Operations Lead and Finance team about the incident.
+4. **Investigate** – Use cloud billing tools to narrow down the cause. Check recent deployments or configuration changes.
+5. **Remediate** – Roll back deployments or adjust resource allocations as needed.
+6. **Postmortem** – Document the incident in Confluence, including root cause and preventive actions.
+
+Store this document in Confluence and update it whenever procedures change.

--- a/docs/handoff/ESCALATION_PROCESS.md
+++ b/docs/handoff/ESCALATION_PROCESS.md
@@ -1,0 +1,9 @@
+# Support Escalation Process
+
+This document defines how issues are escalated from the support team back to the development team.
+
+1. **Triage** – Support reviews incoming tickets and attempts to resolve using the runbooks.
+2. **Escalate to Operations Lead** – If a ticket requires code changes or is unresolved after initial troubleshooting, escalate to the Operations Lead.
+3. **Create GitHub Issue** – The Operations Lead opens a GitHub issue referencing the customer ticket and assigns it to the appropriate developer.
+4. **Communication** – Keep the original reporter updated via the ticketing system. Major incidents trigger a Slack channel notification to #on-call.
+5. **Resolution and Documentation** – After the fix is deployed, document the root cause and steps taken in Confluence.

--- a/docs/handoff/TRAINING_GUIDE.md
+++ b/docs/handoff/TRAINING_GUIDE.md
@@ -1,0 +1,15 @@
+# Operations Training Guide
+
+This guide accompanies the presentation slides used during handoff training.
+
+## Slide Deck Overview
+
+1. **System Architecture** – Diagram of major components and data flow.
+2. **Deployment Process** – Steps for rolling out new versions using the CI/CD pipeline.
+3. **Monitoring and Alerts** – How to access dashboards and respond to alerts.
+4. **Common Runbooks** – Where to find runbooks like the Cost Alert Runbook.
+5. **Escalation Process** – Summary of the support escalation procedure.
+
+## Training Sessions
+
+Conduct at least one live session with the operations and support teams. Record attendance in Confluence under `Security_Training_Log`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,3 +17,7 @@ nav:
       - Core Agent Loop: CORE_AGENT_LOOP.md
       - Atlassian Integration: ATLASSIAN_INTEGRATION.md
       - RAG Architecture: RAG_ARCHITECTURE.md
+  - Operations:
+      - Training Guide: handoff/TRAINING_GUIDE.md
+      - Cost Alert Runbook: handoff/COST_ALERT_RUNBOOK.md
+      - Escalation Process: handoff/ESCALATION_PROCESS.md

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -1019,7 +1019,7 @@
     - 1001
     - 1002
   priority: 3
-  status: "pending"
+  status: "done"
   command: null
   task_id: "PROJ-HANDOFF-001"
   area: "Handoff"


### PR DESCRIPTION
## Summary
- document cost alert runbook
- describe escalation process
- outline operations training guide
- expose new docs in mkdocs navigation
- mark training materials task done

## Testing
- `black . --exclude venv`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872fe72eaf8832a94b0dcba09c92fa3