### PR TITLE
Add BAA template and workflow

### DIFF
--- a/docs/COMPLIANCE_GAP_ANALYSIS.md
+++ b/docs/COMPLIANCE_GAP_ANALYSIS.md
@@ -16,9 +16,9 @@ This document summarizes the regulatory frameworks relevant to the TicketSmith p
 - PII detection and redaction pipeline implemented (task SEC-PII-001).
 - Incident response process documented in `INCIDENT_RESPONSE.md`.
 - OAuth-based access control planned for tool APIs (task SEC-OAUTH-001).
+- BAA template and workflow documented in [BAA Management Workflow](policies/BAA_WORKFLOW.md).
 
 **Gaps**
-- No Business Associate Agreement (BAA) process established.
 - Data encryption at rest and detailed audit logging not documented.
 - Role-based access controls and training programs incomplete.
 

--- a/docs/policies/BAA_TEMPLATE.md
+++ b/docs/policies/BAA_TEMPLATE.md
@@ -1,0 +1,17 @@
+# Business Associate Agreement (BAA) Template
+
+This template defines the standard terms used when TicketSmith engages a vendor that may create, receive, maintain, or transmit protected health information (PHI).
+
+1. **Definitions** – "Business Associate" refers to the vendor. "Covered Entity" refers to TicketSmith.
+2. **Permitted Uses and Disclosures** – PHI may only be used to deliver contracted services.
+3. **Safeguards** – The Business Associate must implement administrative, physical, and technical safeguards in accordance with HIPAA.
+4. **Reporting Obligations** – Any unauthorized use or disclosure of PHI must be reported to TicketSmith within five business days.
+5. **Subcontractors** – Subcontractors that handle PHI must agree to the same protections.
+6. **Termination** – TicketSmith may terminate the agreement for material breach of HIPAA requirements.
+7. **Return or Destruction** – Upon termination, the Business Associate must return or securely destroy all PHI.
+
+**Signatures**
+
+TicketSmith Representative: ______________________
+
+Business Associate Representative: ______________________

--- a/docs/policies/BAA_WORKFLOW.md
+++ b/docs/policies/BAA_WORKFLOW.md
@@ -1,0 +1,21 @@
+# BAA Management Workflow
+
+Use this process to negotiate, execute, and store Business Associate Agreements with vendors that handle PHI.
+
+## Partners Requiring BAAs
+
+| Partner | Service | BAA Required |
+|---------|---------|-------------|
+| OpenAI | GPT-4o API | Yes |
+| Atlassian | Jira/Confluence | Yes |
+| AWS | Hosting Infrastructure | Yes |
+
+## Negotiation and Execution
+
+1. Determine if a new vendor will access or store PHI. If so, create a Jira ticket referencing the BAA template.
+2. Send the template to the vendor and track redlines in the ticket.
+3. Once terms are agreed, obtain signatures via DocuSign.
+4. Store the executed agreement in the Compliance/BAA space in Confluence.
+5. Update the vendor log with execution and renewal dates.
+
+Executed BAAs must be easily accessible for auditors in Confluence.

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -1066,7 +1066,7 @@
   dependencies:
     - 903
   priority: 1
-  status: "pending"
+  status: "done"
   command: null
   task_id: "SEC-BAA-001"
   area: "Compliance"


### PR DESCRIPTION
## Summary
- create BAA template in docs/policies
- document partners that need BAAs and workflow for execution
- note BAA process in the compliance gap analysis
- mark Establish Business Associate Agreement Process task done

## Testing
- `black . --check`
- `flake8`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'opentelemetry')*

------
https://chatgpt.com/codex/tasks/task_e_6873056f7760832a9a30045f8e48a478