### PR TITLE
Implement data encryption at rest documentation

### DIFF
--- a/docs/COMPLIANCE_GAP_ANALYSIS.md
+++ b/docs/COMPLIANCE_GAP_ANALYSIS.md
@@ -17,9 +17,10 @@ This document summarizes the regulatory frameworks relevant to the TicketSmith p
 - Incident response process documented in `INCIDENT_RESPONSE.md`.
 - OAuth-based access control planned for tool APIs (task SEC-OAUTH-001).
 - BAA template and workflow documented in [BAA Management Workflow](policies/BAA_WORKFLOW.md).
+- Data encryption at rest documented in [Data Encryption Policy](policies/DATA_ENCRYPTION_POLICY.md).
 
 **Gaps**
-- Data encryption at rest and detailed audit logging not documented.
+- Detailed audit logging not documented.
 - Role-based access controls and training programs incomplete.
 
 ### ISO 27001

--- a/docs/PRODUCTION_DEPLOYMENT.md
+++ b/docs/PRODUCTION_DEPLOYMENT.md
@@ -28,6 +28,7 @@ This document outlines how to deploy TICKETSMITH in a resilient, scalable manner
 
 - Use automated PostgreSQL backups (e.g., daily snapshots to S3 or the database provider's backup service).
 - Store encryption keys and credentials in the chosen secret manager.
+- Enable storage encryption for the PostgreSQL database and S3 buckets using provider-managed KMS keys.
 - Document the restoration process:
   1. Provision a new database instance.
   2. Restore from the most recent snapshot.

--- a/docs/policies/DATA_ENCRYPTION_POLICY.md
+++ b/docs/policies/DATA_ENCRYPTION_POLICY.md
@@ -3,6 +3,13 @@
 TicketSmith encrypts sensitive data in transit and at rest.
 
 - TLS 1.2+ is required for all network communications.
-- Databases and backups are encrypted using industry-standard algorithms.
-- Encryption keys are stored in a managed secrets system.
+- PostgreSQL (including the `pgvector` extension) runs on a cloud-managed
+  service with storage encryption enabled. In AWS this means using RDS with a
+  customer managed [KMS](https://aws.amazon.com/kms/) key.
+- File and object storage such as S3 buckets use server-side encryption with the
+  same KMS keys.
+- Backups are encrypted at rest and stored in the provider's managed backup
+  service.
+- Encryption keys are kept in the secret manager and managed through KMS with
+  annual rotation and IAM-restricted access.
 

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -1085,7 +1085,7 @@
   dependencies:
     - 801
   priority: 1
-  status: "pending"
+  status: "done"
   command: null
   task_id: "SEC-ENC-001"
   area: "Compliance"


### PR DESCRIPTION
## Summary
- document encryption at rest and key management
- note encryption policy in compliance gap analysis
- mention DB/S3 encryption in production deployment guide
- mark encryption task done in tasks.yaml

## Testing
- `black -q .`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687308b6b538832a997968f556576b97