### PR TITLE
Implement detailed audit logging

### DIFF
--- a/src/ticketsmith/atlassian_auth.py
+++ b/src/ticketsmith/atlassian_auth.py
@@ -6,6 +6,8 @@ import os
 
 from atlassian import Confluence, Jira
 
+from .audit import log_security_event
+
 
 class AtlassianAuthError(RuntimeError):
     """Raised when required authentication variables are missing."""
@@ -24,6 +26,7 @@ def get_jira_client() -> Jira:
     base_url = _get_env("ATLASSIAN_BASE_URL")
     username = _get_env("ATLASSIAN_USERNAME")
     token = _get_env("ATLASSIAN_API_TOKEN")
+    log_security_event("login", user=username, service="jira")
     return Jira(url=base_url, username=username, password=token)
 
 
@@ -32,6 +35,7 @@ def get_confluence_client() -> Confluence:
     base_url = _get_env("ATLASSIAN_BASE_URL")
     username = _get_env("ATLASSIAN_USERNAME")
     token = _get_env("ATLASSIAN_API_TOKEN")
+    log_security_event("login", user=username, service="confluence")
     return Confluence(url=base_url, username=username, password=token)
 
 

--- a/src/ticketsmith/audit.py
+++ b/src/ticketsmith/audit.py
@@ -1,0 +1,63 @@
+"""Audit logging utilities."""
+
+from __future__ import annotations
+
+import logging
+import os
+from logging.handlers import RotatingFileHandler
+from typing import Any
+
+import structlog
+
+# Security-relevant events that should be audited
+SECURITY_EVENTS = {
+    "login",
+    "data_access",
+    "permission_change",
+    "token_validated",
+    "token_invalid",
+    "insufficient_scope",
+}
+
+
+class AppendOnlyRotatingFileHandler(RotatingFileHandler):
+    """Rotating file handler that opens files in append-only mode."""
+
+    def _open(self):  # type: ignore[override]
+        flags = os.O_WRONLY | os.O_APPEND | os.O_CREAT
+        fd = os.open(self.baseFilename, flags, 0o600)
+        return open(fd, self.mode, encoding=self.encoding)
+
+
+def configure_audit_logging(
+    path: str | None = None, max_bytes: int = 1_000_000, backup_count: int = 30
+) -> None:
+    """Configure the dedicated audit logger.
+
+    Args:
+        path: Optional path to the audit log file.
+        max_bytes: Maximum log file size before rotation.
+        backup_count: Number of rotated files to retain.
+    """
+    log_path = path or os.getenv("AUDIT_LOG_PATH", "audit.log")
+    handler = AppendOnlyRotatingFileHandler(
+        log_path,
+        maxBytes=max_bytes,
+        backupCount=backup_count,
+        encoding="utf-8",
+    )
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    logger = logging.getLogger("audit")
+    logger.setLevel(logging.INFO)
+    logger.addHandler(handler)
+    logger.propagate = False
+
+
+_logger = structlog.get_logger("audit")
+
+
+def log_security_event(event: str, user: str, **details: Any) -> None:
+    """Emit an audit log entry for the given security event."""
+    if event not in SECURITY_EVENTS:
+        raise ValueError(f"Unknown security event: {event}")
+    _logger.info(event, user=user, **details)

--- a/src/ticketsmith/cli.py
+++ b/src/ticketsmith/cli.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import click
 
 from .logging_config import configure_logging
+from .audit import configure_audit_logging
 from .tracing import configure_tracing
 from .metrics import start_metrics_server
 
@@ -33,6 +34,7 @@ def dummy_llm(prompt: str) -> str:
 def main(text: str) -> None:
     """Run the core agent once with the provided text."""
     configure_logging()
+    configure_audit_logging()
     configure_tracing()
     start_metrics_server()
     sanitized = sanitize_input(text)

--- a/src/ticketsmith/token_auth.py
+++ b/src/ticketsmith/token_auth.py
@@ -6,6 +6,8 @@ import json
 import os
 from typing import Dict, Set
 
+from .audit import log_security_event
+
 
 class InvalidTokenError(PermissionError):
     """Raised when an access token is missing or invalid."""
@@ -33,6 +35,9 @@ def validate_token(
         token_scopes = load_token_scopes()
     scopes = token_scopes.get(token)
     if scopes is None:
+        log_security_event("token_invalid", user=token)
         raise InvalidTokenError("401 Unauthorized: invalid token")
     if scope not in scopes:
+        log_security_event("insufficient_scope", user=token, scope=scope)
         raise InsufficientScopeError("403 Forbidden: insufficient scope")
+    log_security_event("token_validated", user=token, scope=scope)

--- a/src/ticketsmith/tools.py
+++ b/src/ticketsmith/tools.py
@@ -15,6 +15,7 @@ from .token_auth import (
     load_token_scopes,
     InvalidTokenError,
 )
+from .audit import log_security_event
 
 tracer = trace.get_tracer(__name__)
 
@@ -102,6 +103,12 @@ class ToolDispatcher:
         if not access_token:
             raise InvalidTokenError("401 Unauthorized: missing token")
         validate_token(access_token, tool.scope, self._token_scopes)
+        log_security_event(
+            "data_access",
+            user=access_token,
+            tool=name,
+            scope=tool.scope,
+        )
         if name in self._high_risk and self._approval_client:
             approved = self._approval_client.request_approval(name, kwargs)
             if not approved:

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -1103,7 +1103,7 @@
   dependencies:
     - 801
   priority: 2
-  status: "pending"
+  status: "done"
   command: null
   task_id: "SEC-AUDIT-001"
   area: "Compliance"

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -1,0 +1,50 @@
+import json
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+pkg = types.ModuleType("ticketsmith")
+sys.modules["ticketsmith"] = pkg
+
+spec_sec = importlib.util.spec_from_file_location(
+    "ticketsmith.security", ROOT / "src" / "ticketsmith" / "security.py"
+)
+security = importlib.util.module_from_spec(spec_sec)
+sys.modules["ticketsmith.security"] = security
+assert spec_sec.loader is not None
+spec_sec.loader.exec_module(security)
+
+spec_log = importlib.util.spec_from_file_location(
+    "ticketsmith.logging_config",
+    ROOT / "src" / "ticketsmith" / "logging_config.py",
+)
+logging_config = importlib.util.module_from_spec(spec_log)
+logging_config.__package__ = "ticketsmith"
+sys.modules["ticketsmith.logging_config"] = logging_config
+assert spec_log.loader is not None
+spec_log.loader.exec_module(logging_config)
+
+spec_audit = importlib.util.spec_from_file_location(
+    "ticketsmith.audit",
+    ROOT / "src" / "ticketsmith" / "audit.py",
+)
+audit = importlib.util.module_from_spec(spec_audit)
+audit.__package__ = "ticketsmith"
+sys.modules["ticketsmith.audit"] = audit
+assert spec_audit.loader is not None
+spec_audit.loader.exec_module(audit)
+
+
+def test_audit_log_written(tmp_path):
+    path = tmp_path / "audit.log"
+    logging_config.configure_logging()
+    audit.configure_audit_logging(path=str(path))
+    audit.log_security_event("login", user="alice")
+    with open(path) as f:
+        data = f.read()
+    record = json.loads(data)
+    assert record["event"] == "login"
+    assert record["user"] == "alice"


### PR DESCRIPTION
## Summary
- add audit logging utilities and configure append-only rotating file
- log token events and Atlassian logins
- record tool invocations as data access events
- enable audit logging from CLI
- mark audit logging task as done
- test audit log output

## Testing
- `flake8`
- `pytest tests/test_audit.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68730dad787c832ab39cfa64b0184f4c