### PR TITLE
Add ISMS manual and risk assessment

### DIFF
--- a/docs/policies/INITIAL_RISK_ASSESSMENT.md
+++ b/docs/policies/INITIAL_RISK_ASSESSMENT.md
@@ -1,0 +1,12 @@
+# Initial Risk Assessment
+
+As part of establishing the ISMS, TicketSmith performed a high-level risk assessment.
+The table below lists key threats and the planned treatment actions.
+
+| ID | Threat | Likelihood | Impact | Treatment Plan |
+|----|--------|-----------|--------|---------------|
+| RA1 | Loss of customer support data | Medium | High | Daily backups and restricted database access |
+| RA2 | Unauthorized code changes | Low | Medium | Require pull request reviews and enable branch protection |
+| RA3 | Credential leakage | Medium | High | Store secrets in a vault and rotate API keys quarterly |
+
+Treatment activities are tracked in Jira and progress is reviewed during security meetings. The complete assessment is stored in Confluence under the ISMS space.

--- a/docs/policies/ISMS_MANUAL.md
+++ b/docs/policies/ISMS_MANUAL.md
@@ -1,0 +1,18 @@
+# ISMS Policy Manual
+
+TicketSmith maintains an Information Security Management System (ISMS) aligned with ISO/IEC 27001.
+This manual defines the scope of the program, outlines leadership responsibilities, and lists our security objectives.
+
+## Scope
+The ISMS covers all TicketSmith infrastructure, applications, and data processed on behalf of customers and employees.
+
+## Leadership Commitment
+Executive management provides resources and direction for implementing and continuously improving the ISMS.
+The SecurityLead is accountable for day‑to‑day operation of the program and reports progress during management review meetings.
+
+## Objectives
+- Protect the confidentiality, integrity, and availability of company and customer data.
+- Ensure compliance with contractual and regulatory obligations.
+- Drive ongoing risk reduction through regular assessments and corrective actions.
+
+All ISMS policies, procedures, and assessment reports are stored in Confluence at <https://confluence.example.com/display/TS/ISMS> for auditor reference.

--- a/docs/policies/ISMS_POLICY.md
+++ b/docs/policies/ISMS_POLICY.md
@@ -8,3 +8,4 @@ Key principles:
 - Risks are identified and treated according to the methodology in the Risk Register.
 - Policies and procedures are published in Confluence and kept up to date.
 
+- The full ISMS manual and risk assessment results are stored in Confluence for auditors.

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -1142,7 +1142,7 @@
   dependencies:
     - 906
   priority: 1
-  status: "pending"
+  status: "done"
   command: null
   task_id: "SEC-ISMS-001"
   area: "Compliance"


### PR DESCRIPTION
## Summary
- document a new ISMS Policy Manual
- add an initial risk assessment with treatment plans
- mention Confluence storage in ISMS policy
- mark the ISMS task as complete in `tasks.yaml`

## Testing
- `black . --exclude venv --check`
- `flake8`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'structlog')*

------
https://chatgpt.com/codex/tasks/task_e_6873167f8d88832abd4a0afa544ffcf8