### PR TITLE
Add internal audit procedures

### DIFF
--- a/docs/COMPLIANCE_GAP_ANALYSIS.md
+++ b/docs/COMPLIANCE_GAP_ANALYSIS.md
@@ -27,11 +27,11 @@ This document summarizes the regulatory frameworks relevant to the TicketSmith p
 **Current Controls**
 - Security policies and ISMS framework planned (task SEC-POLICY-001).
 - Initial security model includes token-based authentication and PII handling.
+- Internal audit program with scheduled management reviews documented in
+  [Internal Audit Program](policies/INTERNAL_AUDIT_PROGRAM.md).
 
 **Gaps**
 - Formal ISMS documentation and risk assessments not yet created.
-- No regular internal audit process defined.
-- Limited evidence of continuous improvement or management review.
 
 ### FISMA
 **Current Controls**

--- a/docs/policies/INTERNAL_AUDIT_PROGRAM.md
+++ b/docs/policies/INTERNAL_AUDIT_PROGRAM.md
@@ -1,0 +1,16 @@
+# Internal Audit Program
+
+TicketSmith conducts periodic internal audits to verify that its Information Security Management System complies with ISO/IEC 27001.
+
+## Audit Procedure
+- The SecurityLead maintains a quarterly schedule covering all control areas.
+- Each audit documents scope, evidence, and findings in Confluence.
+- Follow a risk-based approach when selecting samples and test methods.
+
+## Auditor Training
+- Staff assigned to perform audits receive annual training on ISO 27001 requirements and audit techniques.
+- Completion of training sessions is recorded in `SECURITY_TRAINING_LOG.md`.
+
+## Management Review
+- After each audit cycle, executive management reviews results and corrective actions.
+- Meeting notes and decisions are stored alongside audit reports in Confluence.

--- a/docs/policies/ISMS_MANUAL.md
+++ b/docs/policies/ISMS_MANUAL.md
@@ -16,3 +16,6 @@ The SecurityLead is accountable for day‑to‑day operation of the program and 
 - Drive ongoing risk reduction through regular assessments and corrective actions.
 
 All ISMS policies, procedures, and assessment reports are stored in Confluence at <https://confluence.example.com/display/TS/ISMS> for auditor reference.
+
+## Internal Audits and Management Review
+Periodic internal audits are performed according to the [Internal Audit Program](INTERNAL_AUDIT_PROGRAM.md). Results are discussed during management review meetings to drive continuous improvement.

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -1161,7 +1161,7 @@
   dependencies:
     - 1009
   priority: 2
-  status: "pending"
+  status: "done"
   command: null
   task_id: "SEC-AUDIT-INT-001"
   area: "Compliance"


### PR DESCRIPTION
## Summary
- document internal audit program and management reviews
- link the new program from ISMS manual and gap analysis
- mark the internal audit task as done in `tasks.yaml`

## Testing
- `black . --check`
- `flake8`
- `pytest -q` *(fails: ModuleNotFoundError: opentelemetry.trace)*

------
https://chatgpt.com/codex/tasks/task_e_687318a95974832aa6832e53fd6b3245