### PR TITLE
Add SOC2 policy docs

### DIFF
--- a/docs/COMPLIANCE_GAP_ANALYSIS.md
+++ b/docs/COMPLIANCE_GAP_ANALYSIS.md
@@ -45,9 +45,12 @@ This document summarizes the regulatory frameworks relevant to the TicketSmith p
 ### SOC 2
 **Current Controls**
 - Logging, incident response, and OAuth scopes planned provide a baseline for security and availability.
+- Formal change management, vendor due diligence, and business continuity policies documented in
+  [Change Management Policy](policies/CHANGE_MANAGEMENT_POLICY.md),
+  [Vendor Due Diligence Policy](policies/VENDOR_DUE_DILIGENCE_POLICY.md), and
+  [Business Continuity and Disaster Recovery Plan](policies/BUSINESS_CONTINUITY_PLAN.md).
 
 **Gaps**
-- Formal policies for change management, vendor management, and business continuity not documented.
 - Independent SOC 2 audit has not been scheduled.
 
 ### GDPR

--- a/docs/policies/BUSINESS_CONTINUITY_PLAN.md
+++ b/docs/policies/BUSINESS_CONTINUITY_PLAN.md
@@ -1,0 +1,8 @@
+# Business Continuity and Disaster Recovery Plan
+
+This plan ensures TicketSmith can continue critical operations during disruptive events.
+
+- Daily backups of databases and configuration are stored in geographically separate locations.
+- Critical staff contact information is maintained in the incident response wiki.
+- Cloud infrastructure can be restored in a new region using infrastructure-as-code templates.
+- Tabletop exercises are performed annually and results are recorded in Confluence.

--- a/docs/policies/CHANGE_MANAGEMENT_POLICY.md
+++ b/docs/policies/CHANGE_MANAGEMENT_POLICY.md
@@ -1,0 +1,9 @@
+# Change Management Policy
+
+All changes to production systems must follow a documented approval process.
+
+- Propose changes through a pull request linked to a Jira ticket.
+- Peer review is required before merging.
+- High-risk changes need system owner approval.
+- Emergency fixes may be deployed immediately but must be reviewed within one business day.
+- Each change record includes deployment steps and rollback procedures.

--- a/docs/policies/VENDOR_DUE_DILIGENCE_POLICY.md
+++ b/docs/policies/VENDOR_DUE_DILIGENCE_POLICY.md
@@ -1,0 +1,8 @@
+# Vendor Due Diligence Policy
+
+TicketSmith assesses vendors for security and compliance risks before engagement.
+
+1. Complete a vendor risk questionnaire covering data handling and control maturity.
+2. Review security certifications and recent audit reports.
+3. Require contractual commitments for breach notification and data protection.
+4. Track ongoing monitoring results in the vendor log and review annually.

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -1236,7 +1236,7 @@
   dependencies:
     - 906
   priority: 2
-  status: "pending"
+  status: "done"
   command: null
   task_id: "SEC-SOC2-POL-001"
   area: "Compliance"


### PR DESCRIPTION
## Summary
- add change management, vendor due diligence, and continuity policies
- note new policies in SOC 2 gap analysis
- mark task SEC-SOC2-POL-001 done

## Testing
- `black --check .`
- `flake8`
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_687456ae7144832a8204d45fd6bd6a03