### PR TITLE
Add GDPR data request workflow

### DIFF
--- a/docs/policies/DATA_REQUEST_WORKFLOW.md
+++ b/docs/policies/DATA_REQUEST_WORKFLOW.md
@@ -1,0 +1,12 @@
+# Data Deletion and Export Workflow
+
+Users may request deletion or export of their personal data at any time. Follow this process to handle requests and maintain auditability.
+
+1. **Submit Request** – The user opens a support ticket or emails compliance.
+2. **Verify Identity** – Confirm the requester owns the account and data.
+3. **Track in Jira** – Create a Jira ticket referencing the request.
+4. **Run Tools** – Use the `delete_user_data` or `export_user_data` scripts to locate and process the user's data.
+5. **Log Actions** – All tool executions write to `audit.log` for compliance records.
+6. **Notify User** – Inform the requester when the task is complete and attach the Jira ticket.
+
+Store completed requests and logs in Confluence for future audits.

--- a/src/ticketsmith/audit.py
+++ b/src/ticketsmith/audit.py
@@ -17,6 +17,8 @@ SECURITY_EVENTS = {
     "token_validated",
     "token_invalid",
     "insufficient_scope",
+    "data_deletion",
+    "data_export",
 }
 
 

--- a/src/ticketsmith/data_requests.py
+++ b/src/ticketsmith/data_requests.py
@@ -1,0 +1,41 @@
+"""Utilities for GDPR data deletion and export requests."""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+from .audit import log_security_event
+
+
+def delete_user_data(user_id: str, path: str) -> None:
+    """Delete a user's data file and log the action.
+
+    Args:
+        user_id: Identifier for the user.
+        path: File path containing the user's data.
+    """
+    file_path = Path(path)
+    if not file_path.exists():
+        raise FileNotFoundError(path)
+    file_path.unlink()
+    log_security_event("data_deletion", user=user_id, path=str(file_path))
+
+
+def export_user_data(user_id: str, source: str, destination: str) -> None:
+    """Export user data to ``destination`` and log the action.
+
+    Args:
+        user_id: Identifier for the user.
+        source: Path to the source data file.
+        destination: Location to copy the data.
+    """
+    src = Path(source)
+    dest = Path(destination)
+    if not src.exists():
+        raise FileNotFoundError(source)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(src, dest)
+    log_security_event(
+        "data_export", user=user_id, source=str(src), destination=str(dest)
+    )

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -1289,7 +1289,7 @@
   dependencies:
     - 1016
   priority: 2
-  status: "pending"
+  status: "done"
   command: null
   task_id: "SEC-GDPR-RTBF-001"
   area: "Compliance"

--- a/tests/test_data_requests.py
+++ b/tests/test_data_requests.py
@@ -1,0 +1,33 @@
+import json
+from ticketsmith.logging_config import configure_logging
+from ticketsmith.audit import configure_audit_logging
+from ticketsmith.data_requests import delete_user_data, export_user_data
+
+
+def test_delete_user_data(tmp_path):
+    log = tmp_path / "audit.log"
+    data = tmp_path / "u.txt"
+    data.write_text("secret")
+    configure_logging()
+    configure_audit_logging(path=str(log))
+    delete_user_data("u1", str(data))
+    assert not data.exists()
+    with open(log) as f:
+        rec = json.loads(f.read())
+    assert rec["event"] == "data_deletion"
+    assert rec["user"] == "u1"
+
+
+def test_export_user_data(tmp_path):
+    log = tmp_path / "audit.log"
+    src = tmp_path / "u.txt"
+    dest = tmp_path / "export" / "u.txt"
+    src.write_text("info")
+    configure_logging()
+    configure_audit_logging(path=str(log))
+    export_user_data("u2", str(src), str(dest))
+    assert dest.exists()
+    with open(log) as f:
+        rec = json.loads(f.read())
+    assert rec["event"] == "data_export"
+    assert rec["user"] == "u2"


### PR DESCRIPTION
## Summary
- implement scripts to delete or export user data
- log new security events for data requests
- document Data Deletion and Export Workflow
- test new data request utilities
- mark GDPR data request handling task done

## Testing
- `pytest tests/test_data_requests.py tests/test_audit.py -q`
- `pytest -q --ignore=tests/test_audit.py --ignore=tests/test_data_requests.py`


------
https://chatgpt.com/codex/tasks/task_e_6874c2cbb7ec832aa4c7e788cb8da391